### PR TITLE
[Add] CORS headers to support Blazor (and other framework) web-app development; fixes #60

### DIFF
--- a/CDP4WebServices.API/Cdp4Bootstrapper.cs
+++ b/CDP4WebServices.API/Cdp4Bootstrapper.cs
@@ -271,6 +271,20 @@ namespace CDP4WebServices.API
             MigrationEngine.MigrateAllAtStartUp();
         }
 
+        
+        protected override void RequestStartup(ILifetimeScope container, IPipelines pipelines, NancyContext context)
+        {
+            //Enable CORS 
+            pipelines.AfterRequest.AddItemToEndOfPipeline((ctx) =>
+            {
+                ctx.Response
+                    .WithHeader("Access-Control-Allow-Origin", "*")
+                    .WithHeader("Access-Control-Allow-Methods", "PUT, GET, POST, DELETE, OPTIONS")
+                    .WithHeader("Access-Control-Allow-Headers", "Content-Type, x-requested-with, Authorization, Accept, Origin, user-agent, Accept-CDP, CDP4-Token, CDP4-Common, CDP4-Server")
+                    .WithHeader("Access-Control-Expose-Headers", "Content-Type, x-requested-with, Authorization, Accept, Origin, user-agent, Accept-CDP, CDP4-Token, CDP4-Common, CDP4-Server");
+            });
+        }
+
         #region Support Property Injection on Nancy Modules
         /// <summary>
         /// Retrieve a specific module instance from the container


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Add CORS headers in the `override RequestStartup` method of the bootstrapper. Verified with a test blazor app that CDP4ServicesDal-CE and WspDal can open a session and return the `SiteDirectory` POCO

<!-- Thanks for contributing to CDP4 Web Services! -->