### PR TITLE
Update OperationProcessor to take reordering into account for updating the container as well

### DIFF
--- a/CDP4WebServices.API/Services/BusinessLogic/IOldParameterContextProvider.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/IOldParameterContextProvider.cs
@@ -25,7 +25,7 @@ namespace CDP4WebServices.API.Services.BusinessLogic
         /// <param name="partition">The current partition</param>
         /// <param name="securityContext">The security context</param>
         /// <param name="iteration">The current <see cref="Iteration"/> (nullable)</param>
-        void Initialize(Parameter oldParameter, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext, Iteration iteration = null);
+        void Initialize(Parameter oldParameter, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext, Iteration iteration);
 
         /// <summary>
         /// Gets the source <see cref="ParameterValueSet"/> for the new one to be created for a specified option and state
@@ -34,5 +34,11 @@ namespace CDP4WebServices.API.Services.BusinessLogic
         /// <param name="state">The identifier of the state</param>
         /// <returns>The source <see cref="ParameterValueSet"/></returns>
         ParameterValueSet GetsourceValueSet(Guid? option, Guid? state);
+
+        /// <summary>
+        /// Gets the default value 
+        /// </summary>
+        /// <returns>The default <see cref="ParameterValueSet"/></returns>
+        ParameterValueSet GetDefaultValue();
     }
 }

--- a/CDP4WebServices.API/Services/Operations/OperationProcessor.cs
+++ b/CDP4WebServices.API/Services/Operations/OperationProcessor.cs
@@ -1204,9 +1204,11 @@ namespace CDP4WebServices.API.Services.Operations
                                 foreach (var orderedItemUpdate in orderedCollectionItems.Where(x => x.M.HasValue))
                                 {
                                     orderedItemUpdate.MoveItem(orderedItemUpdate.K, orderedItemUpdate.M.Value);
-                                        
+
                                     // try apply collection property reorder
-                                    if (!service.ReorderCollectionProperty(transaction, resolvedInfo.Partition, propertyName, resolvedInfo.InstanceInfo.Iid, orderedItemUpdate))
+                                    isUpdated = service.ReorderCollectionProperty(transaction, resolvedInfo.Partition, propertyName, resolvedInfo.InstanceInfo.Iid, orderedItemUpdate);
+
+                                    if (!isUpdated)
                                     { 
                                         Logger.Info(
                                             "The item '{0}' order update from sequence {1} to {2} of {3}.{4} with iid: '{5}' could not be performed.",
@@ -1251,7 +1253,9 @@ namespace CDP4WebServices.API.Services.Operations
                                     };
                                     orderedItemUpdate.MoveItem(orderUpdateItemInfo.K, orderUpdateItemInfo.M.Value);
 
-                                    if (!containedThingService.ReorderContainment(transaction, resolvedInfo.Partition, orderedItemUpdate))
+                                    isUpdated = containedThingService.ReorderContainment(transaction, resolvedInfo.Partition, orderedItemUpdate);
+
+                                    if (!isUpdated)
                                     {
                                             Logger.Info(
                                                 "The contained item '{0}' with iid: '{1}' could not be reordered.",


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

a fix for https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/issues/62. Too many objects are stil being returned though for which a new issue should be created. Since in the database a reorder is an update on the items of the list, not the container of the list... This is caused by the trigger that updates the revision of Things that are added, updated or deleted. This trigger is "too trigger happy".

<!-- Thanks for contributing to CDP4 Web Services! -->