### PR TITLE
Multiple model export issue is fixed

### DIFF
--- a/CDP4Orm.Tests/CDP4Orm.Tests.csproj
+++ b/CDP4Orm.Tests/CDP4Orm.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CDP4JsonSerializer-CE" Version="3.1.0-rc2" />
+    <PackageReference Include="CDP4JsonSerializer-CE" Version="2019.12.4.3" />
     <PackageReference Include="Npgsql" Version="3.2.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/CDP4Orm/CDP4Orm.csproj
+++ b/CDP4Orm/CDP4Orm.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CDP4JsonSerializer-CE" Version="3.1.0-rc2" />
+    <PackageReference Include="CDP4JsonSerializer-CE" Version="2019.12.4.3" />
     <PackageReference Include="Npgsql" Version="3.2.7" />
   </ItemGroup>
   

--- a/CDP4WebServices.API.Tests/CDP4WebServices.API.Tests.csproj
+++ b/CDP4WebServices.API.Tests/CDP4WebServices.API.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CDP4JsonSerializer-CE" Version="3.1.0-rc2" />
+    <PackageReference Include="CDP4JsonSerializer-CE" Version="2019.12.4.3" />
     <PackageReference Include="DotNetZip" Version="1.13.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Nancy" Version="1.4.5" />

--- a/CDP4WebServices.API/CDP4WebServices.API.csproj
+++ b/CDP4WebServices.API/CDP4WebServices.API.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CDP4JsonSerializer-CE" Version="3.1.0-rc2" />
+    <PackageReference Include="CDP4JsonSerializer-CE" Version="2019.12.4.3" />
     <PackageReference Include="DotNetZip" Version="1.13.2" />
     <PackageReference Include="Nancy.Bootstrappers.Autofac" Version="1.4.1" />
     <PackageReference Include="Npgsql" Version="3.2.7" />    

--- a/CDP4WebServices.API/Modules/10-25/ApiBase.cs
+++ b/CDP4WebServices.API/Modules/10-25/ApiBase.cs
@@ -659,6 +659,11 @@ namespace CDP4WebServices.API.Modules
 
             try
             {
+                if (path == null)
+                {
+                    throw new Exception("The server was unable to export EngineeringModel. You might not be eligible to export some models, please check your permissions or contact your administrator.");
+                }
+
                 // create a new response with contents assigned by stream
                 var response = new Response
                 {
@@ -678,7 +683,10 @@ namespace CDP4WebServices.API.Modules
                     string.Format("exception:{0}", ex.Message),
                     new DefaultJsonSerializer());
 
-                System.IO.File.Delete(path);
+                if (path != null)
+                {
+                    System.IO.File.Delete(path);
+                }
 
                 return errorResponse.WithStatusCode(HttpStatusCode.InternalServerError);
             }

--- a/CDP4WebServices.API/Services/BusinessLogic/Implementation/EngineeringModelZipExportService.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/Implementation/EngineeringModelZipExportService.cs
@@ -13,6 +13,7 @@ namespace CDP4WebServices.API.Services
     using System.Text.RegularExpressions;
 
     using CDP4Common.CommonData;
+    using CDP4Common.Comparers;
     using CDP4Common.DTO;
     using CDP4Common.Extensions;
 
@@ -183,7 +184,7 @@ namespace CDP4WebServices.API.Services
                 this.RequestUtils.MetaInfoProvider,
                 this.RequestUtils.GetRequestDataModelVersion);
 
-            var siteReferenceDataLibraries = new HashSet<SiteReferenceDataLibrary>(new ThingComparer());
+            var siteReferenceDataLibraries = new HashSet<SiteReferenceDataLibrary>(new DtoThingIidComparer());
             var credentials = this.Cdp4Context.Context.CurrentUser as Credentials;
             var authorizedContext = new RequestSecurityContext { ContainerReadAllowed = true };
 
@@ -210,7 +211,7 @@ namespace CDP4WebServices.API.Services
                     .ToList();
 
                 // Get all DomainOfExpertises that are contained by the EngineeringModelSetups
-                var domainsOfExpertises = new HashSet<DomainOfExpertise>(new ThingComparer());
+                var domainsOfExpertises = new HashSet<DomainOfExpertise>(new DtoThingIidComparer());
                 foreach (var engineeringModelSetup in engineeringModelSetups)
                 {
                     var activeDomains = this.DomainOfExpertiseService
@@ -1051,29 +1052,6 @@ namespace CDP4WebServices.API.Services
             // Set the state of the credentials and the participant flag before retrieving EngineeringModel data
             credentials.IsParticipant = currentParticipantFlag;
             this.PermissionService.Credentials = credentials;
-        }
-
-        /// <summary>
-        /// An implementation of <see cref="IEqualityComparer{Thing}"/> for <see cref="CDP4Common.DTO.Thing"/> to be used in <see cref="HashSet{Thing}"/>.
-        /// </summary>
-        private class ThingComparer : IEqualityComparer<Thing>
-        {
-            public bool Equals(Thing t1, Thing t2)
-            {
-                if (t2 == null && t1 == null)
-                    return true;
-                else if (t1 == null || t2 == null)
-                    return false;
-                else if (t1.Iid.Equals(t2.Iid))
-                    return true;
-                else
-                    return false;
-            }
-
-            public int GetHashCode(Thing thing)
-            {
-                return thing.Iid.GetHashCode();
-            }
         }
     }
 }

--- a/CDP4WebServices.API/Services/BusinessLogic/Implementation/EngineeringModelZipExportService.cs
+++ b/CDP4WebServices.API/Services/BusinessLogic/Implementation/EngineeringModelZipExportService.cs
@@ -210,7 +210,7 @@ namespace CDP4WebServices.API.Services
                     .ToList();
 
                 // Get all DomainOfExpertises that are contained by the EngineeringModelSetups
-                List<DomainOfExpertise> domainsOfExpertises = new List<DomainOfExpertise>();
+                var domainsOfExpertises = new HashSet<DomainOfExpertise>(new ThingComparer());
                 foreach (var engineeringModelSetup in engineeringModelSetups)
                 {
                     var activeDomains = this.DomainOfExpertiseService
@@ -219,7 +219,8 @@ namespace CDP4WebServices.API.Services
                             siteDirectoryPartition,
                             engineeringModelSetup.ActiveDomain,
                             authorizedContext).OfType<DomainOfExpertise>().ToList();
-                    domainsOfExpertises.AddRange(activeDomains);
+
+                    activeDomains.ForEach(x => domainsOfExpertises.Add(x));
                 }
 
                 // Get all ModelReferenceDataLibraris that are contained by the EngineeringModelSetups
@@ -487,7 +488,7 @@ namespace CDP4WebServices.API.Services
         private IEnumerable<Thing> CreateSiteDirectoryAndPrunedContainedThingDtos(
             SiteDirectory siteDirectory,
             HashSet<SiteReferenceDataLibrary> siteReferenceDataLibraries,
-            IEnumerable<DomainOfExpertise> domainOfExpertises,
+            HashSet<DomainOfExpertise> domainOfExpertises,
             HashSet<Person> persons,
             IEnumerable<EngineeringModelSetup> engineeringModelSetups,
             NpgsqlTransaction transaction,

--- a/Nuget.Config
+++ b/Nuget.Config
@@ -3,5 +3,6 @@
   <packageSources>
     <clear />    
 	<add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+	<add key="CDP4-SDK Pre Release" value="https://pkgs.dev.azure.com/RHEAGROUP/CDP-SDK/_packaging/cdp4-sdk-pre-release/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
[Fix] an issue for a SiteReferenceDataLibrary HashSet
[Add] a little bit more comprehensible error messages from the server and some necessary checks

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The issue was that SiteReferenceDataLibrary HashSet relied on default equality implementation which is link comparison, but the code produces SRDLs dtos that are equal, but because they have different links they were added and zip failed for duplicates.

<!-- Thanks for contributing to CDP4 Web Services! -->