### PR TITLE
[Update] code generated DAO files, remove multi-column syntax from UPDATE statement when only one column is updated. Remove obsolete \"ValueTypeDictionary\" || from the UPDATE statement; fixes #85

### DIFF
--- a/CDP4Orm/AutoGenDao/ActionItemDao.cs
+++ b/CDP4Orm/AutoGenDao/ActionItemDao.cs
@@ -318,7 +318,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ActionItem\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Actionee\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :actionee)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :actionee)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = actionItem.Iid;

--- a/CDP4Orm/AutoGenDao/ActualFiniteStateDao.cs
+++ b/CDP4Orm/AutoGenDao/ActualFiniteStateDao.cs
@@ -333,7 +333,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ActualFiniteState\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = actualFiniteState.Iid;

--- a/CDP4Orm/AutoGenDao/ActualFiniteStateListDao.cs
+++ b/CDP4Orm/AutoGenDao/ActualFiniteStateListDao.cs
@@ -449,8 +449,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ActualFiniteStateList_PossibleFiniteStateList\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.Append(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.Append(" = :reorderSequence");
                 sqlBuilder.Append(" WHERE \"ActualFiniteStateList\" = :actualFiniteStateList");
                 sqlBuilder.Append(" AND \"PossibleFiniteStateList\" = :possibleFiniteStateList");
                 sqlBuilder.Append(" AND \"Sequence\" = :sequence;");

--- a/CDP4Orm/AutoGenDao/AliasDao.cs
+++ b/CDP4Orm/AutoGenDao/AliasDao.cs
@@ -267,7 +267,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Alias\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = alias.Iid;

--- a/CDP4Orm/AutoGenDao/ApprovalDao.cs
+++ b/CDP4Orm/AutoGenDao/ApprovalDao.cs
@@ -273,7 +273,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Approval\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Author\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :author, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :author, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = approval.Iid;

--- a/CDP4Orm/AutoGenDao/ArrayParameterTypeDao.cs
+++ b/CDP4Orm/AutoGenDao/ArrayParameterTypeDao.cs
@@ -368,8 +368,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ArrayParameterType\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = arrayParameterType.Iid;
@@ -452,8 +452,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ArrayParameterType_Dimension\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.Append(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.Append(" = :reorderSequence");
                 sqlBuilder.Append(" WHERE \"ArrayParameterType\" = :arrayParameterType");
                 sqlBuilder.Append(" AND \"Dimension\" = :dimension");
                 sqlBuilder.Append(" AND \"Sequence\" = :sequence;");

--- a/CDP4Orm/AutoGenDao/BinaryNoteDao.cs
+++ b/CDP4Orm/AutoGenDao/BinaryNoteDao.cs
@@ -272,7 +272,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"BinaryNote\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"FileType\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :fileType)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :fileType)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = binaryNote.Iid;

--- a/CDP4Orm/AutoGenDao/BinaryRelationshipRuleDao.cs
+++ b/CDP4Orm/AutoGenDao/BinaryRelationshipRuleDao.cs
@@ -285,7 +285,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"BinaryRelationshipRule\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"RelationshipCategory\", \"SourceCategory\", \"TargetCategory\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :relationshipCategory, :sourceCategory, :targetCategory)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :relationshipCategory, :sourceCategory, :targetCategory)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = binaryRelationshipRule.Iid;

--- a/CDP4Orm/AutoGenDao/BookDao.cs
+++ b/CDP4Orm/AutoGenDao/BookDao.cs
@@ -356,7 +356,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Book\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = book.Iid;
@@ -397,8 +397,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Book\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/BooleanExpressionDao.cs
+++ b/CDP4Orm/AutoGenDao/BooleanExpressionDao.cs
@@ -120,8 +120,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"BooleanExpression\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = booleanExpression.Iid;

--- a/CDP4Orm/AutoGenDao/BoundsDao.cs
+++ b/CDP4Orm/AutoGenDao/BoundsDao.cs
@@ -281,7 +281,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Bounds\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = bounds.Iid;

--- a/CDP4Orm/AutoGenDao/CategoryDao.cs
+++ b/CDP4Orm/AutoGenDao/CategoryDao.cs
@@ -403,7 +403,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Category\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = category.Iid;
@@ -450,7 +450,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Category\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/ChangeProposalDao.cs
+++ b/CDP4Orm/AutoGenDao/ChangeProposalDao.cs
@@ -284,8 +284,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ChangeProposal\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ChangeRequest\")");
-                    sqlBuilder.AppendFormat(" = (:changeRequest)");
+                    sqlBuilder.AppendFormat(" SET \"ChangeRequest\"");
+                    sqlBuilder.AppendFormat(" = :changeRequest");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = changeProposal.Iid;

--- a/CDP4Orm/AutoGenDao/CitationDao.cs
+++ b/CDP4Orm/AutoGenDao/CitationDao.cs
@@ -277,7 +277,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Citation\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Source\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :source)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :source)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = citation.Iid;

--- a/CDP4Orm/AutoGenDao/ColorDao.cs
+++ b/CDP4Orm/AutoGenDao/ColorDao.cs
@@ -273,7 +273,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Color\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = color.Iid;

--- a/CDP4Orm/AutoGenDao/CommonFileStoreDao.cs
+++ b/CDP4Orm/AutoGenDao/CommonFileStoreDao.cs
@@ -248,8 +248,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"CommonFileStore\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = commonFileStore.Iid;

--- a/CDP4Orm/AutoGenDao/CompoundParameterTypeDao.cs
+++ b/CDP4Orm/AutoGenDao/CompoundParameterTypeDao.cs
@@ -279,8 +279,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"CompoundParameterType\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = compoundParameterType.Iid;

--- a/CDP4Orm/AutoGenDao/ConstantDao.cs
+++ b/CDP4Orm/AutoGenDao/ConstantDao.cs
@@ -360,7 +360,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Constant\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"ParameterType\", \"Scale\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :parameterType, :scale)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :parameterType, :scale)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = constant.Iid;
@@ -409,7 +409,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Constant\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/ContractChangeNoticeDao.cs
+++ b/CDP4Orm/AutoGenDao/ContractChangeNoticeDao.cs
@@ -284,8 +284,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ContractChangeNotice\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ChangeProposal\")");
-                    sqlBuilder.AppendFormat(" = (:changeProposal)");
+                    sqlBuilder.AppendFormat(" SET \"ChangeProposal\"");
+                    sqlBuilder.AppendFormat(" = :changeProposal");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = contractChangeNotice.Iid;

--- a/CDP4Orm/AutoGenDao/ConversionBasedUnitDao.cs
+++ b/CDP4Orm/AutoGenDao/ConversionBasedUnitDao.cs
@@ -132,7 +132,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ConversionBasedUnit\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"ReferenceUnit\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :referenceUnit)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :referenceUnit)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = conversionBasedUnit.Iid;

--- a/CDP4Orm/AutoGenDao/CyclicRatioScaleDao.cs
+++ b/CDP4Orm/AutoGenDao/CyclicRatioScaleDao.cs
@@ -315,8 +315,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"CyclicRatioScale\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = cyclicRatioScale.Iid;

--- a/CDP4Orm/AutoGenDao/DecompositionRuleDao.cs
+++ b/CDP4Orm/AutoGenDao/DecompositionRuleDao.cs
@@ -363,7 +363,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DecompositionRule\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"ContainingCategory\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :containingCategory)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :containingCategory)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = decompositionRule.Iid;

--- a/CDP4Orm/AutoGenDao/DefinedThingDao.cs
+++ b/CDP4Orm/AutoGenDao/DefinedThingDao.cs
@@ -132,8 +132,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DefinedThing\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = definedThing.Iid;

--- a/CDP4Orm/AutoGenDao/DefinitionDao.cs
+++ b/CDP4Orm/AutoGenDao/DefinitionDao.cs
@@ -391,7 +391,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Definition\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = definition.Iid;
@@ -481,8 +481,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Definition_Example\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.Append(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.Append(" = :reorderSequence");
                 sqlBuilder.Append(" WHERE \"Definition\" = :definition");
                 sqlBuilder.Append(" AND \"Example\" = :example");
                 sqlBuilder.Append(" AND \"Sequence\" = :sequence;");
@@ -524,8 +524,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Definition_Note\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.Append(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.Append(" = :reorderSequence");
                 sqlBuilder.Append(" WHERE \"Definition\" = :definition");
                 sqlBuilder.Append(" AND \"Note\" = :note");
                 sqlBuilder.Append(" AND \"Sequence\" = :sequence;");

--- a/CDP4Orm/AutoGenDao/DiagramCanvasDao.cs
+++ b/CDP4Orm/AutoGenDao/DiagramCanvasDao.cs
@@ -259,7 +259,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DiagramCanvas\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = diagramCanvas.Iid;

--- a/CDP4Orm/AutoGenDao/DiagramObjectDao.cs
+++ b/CDP4Orm/AutoGenDao/DiagramObjectDao.cs
@@ -268,8 +268,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DiagramObject\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = diagramObject.Iid;

--- a/CDP4Orm/AutoGenDao/DiagramThingBaseDao.cs
+++ b/CDP4Orm/AutoGenDao/DiagramThingBaseDao.cs
@@ -130,8 +130,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DiagramThingBase\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = diagramThingBase.Iid;

--- a/CDP4Orm/AutoGenDao/DiagrammingStyleDao.cs
+++ b/CDP4Orm/AutoGenDao/DiagrammingStyleDao.cs
@@ -150,7 +150,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DiagrammingStyle\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"FillColor\", \"FontColor\", \"StrokeColor\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :fillColor, :fontColor, :strokeColor)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :fillColor, :fontColor, :strokeColor)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = diagrammingStyle.Iid;

--- a/CDP4Orm/AutoGenDao/DiscussionItemDao.cs
+++ b/CDP4Orm/AutoGenDao/DiscussionItemDao.cs
@@ -120,8 +120,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DiscussionItem\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ReplyTo\")");
-                    sqlBuilder.AppendFormat(" = (:replyTo)");
+                    sqlBuilder.AppendFormat(" SET \"ReplyTo\"");
+                    sqlBuilder.AppendFormat(" = :replyTo");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = discussionItem.Iid;

--- a/CDP4Orm/AutoGenDao/DomainFileStoreDao.cs
+++ b/CDP4Orm/AutoGenDao/DomainFileStoreDao.cs
@@ -266,7 +266,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DomainFileStore\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = domainFileStore.Iid;

--- a/CDP4Orm/AutoGenDao/DomainOfExpertiseDao.cs
+++ b/CDP4Orm/AutoGenDao/DomainOfExpertiseDao.cs
@@ -348,7 +348,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DomainOfExpertise\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = domainOfExpertise.Iid;
@@ -395,7 +395,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DomainOfExpertise\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/DomainOfExpertiseGroupDao.cs
+++ b/CDP4Orm/AutoGenDao/DomainOfExpertiseGroupDao.cs
@@ -348,7 +348,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DomainOfExpertiseGroup\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = domainOfExpertiseGroup.Iid;
@@ -395,7 +395,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"DomainOfExpertiseGroup\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/ElementBaseDao.cs
+++ b/CDP4Orm/AutoGenDao/ElementBaseDao.cs
@@ -201,8 +201,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ElementBase\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Owner\")");
-                    sqlBuilder.AppendFormat(" = (:owner)");
+                    sqlBuilder.AppendFormat(" SET \"Owner\"");
+                    sqlBuilder.AppendFormat(" = :owner");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = elementBase.Iid;

--- a/CDP4Orm/AutoGenDao/ElementDefinitionDao.cs
+++ b/CDP4Orm/AutoGenDao/ElementDefinitionDao.cs
@@ -335,8 +335,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ElementDefinition\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = elementDefinition.Iid;

--- a/CDP4Orm/AutoGenDao/ElementUsageDao.cs
+++ b/CDP4Orm/AutoGenDao/ElementUsageDao.cs
@@ -353,7 +353,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ElementUsage\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"ElementDefinition\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :elementDefinition)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :elementDefinition)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = elementUsage.Iid;

--- a/CDP4Orm/AutoGenDao/EmailAddressDao.cs
+++ b/CDP4Orm/AutoGenDao/EmailAddressDao.cs
@@ -259,7 +259,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"EmailAddress\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = emailAddress.Iid;

--- a/CDP4Orm/AutoGenDao/EngineeringModelDao.cs
+++ b/CDP4Orm/AutoGenDao/EngineeringModelDao.cs
@@ -246,8 +246,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"EngineeringModel\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"EngineeringModelSetup\")");
-                    sqlBuilder.AppendFormat(" = (:engineeringModelSetup)");
+                    sqlBuilder.AppendFormat(" SET \"EngineeringModelSetup\"");
+                    sqlBuilder.AppendFormat(" = :engineeringModelSetup");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = engineeringModel.Iid;

--- a/CDP4Orm/AutoGenDao/EngineeringModelDataNoteDao.cs
+++ b/CDP4Orm/AutoGenDao/EngineeringModelDataNoteDao.cs
@@ -255,8 +255,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"EngineeringModelDataNote\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = engineeringModelDataNote.Iid;

--- a/CDP4Orm/AutoGenDao/EngineeringModelSetupDao.cs
+++ b/CDP4Orm/AutoGenDao/EngineeringModelSetupDao.cs
@@ -375,7 +375,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"EngineeringModelSetup\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = engineeringModelSetup.Iid;

--- a/CDP4Orm/AutoGenDao/EnumerationParameterTypeDao.cs
+++ b/CDP4Orm/AutoGenDao/EnumerationParameterTypeDao.cs
@@ -278,8 +278,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"EnumerationParameterType\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = enumerationParameterType.Iid;

--- a/CDP4Orm/AutoGenDao/EnumerationValueDefinitionDao.cs
+++ b/CDP4Orm/AutoGenDao/EnumerationValueDefinitionDao.cs
@@ -252,8 +252,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"EnumerationValueDefinition\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = enumerationValueDefinition.Iid;
@@ -292,8 +292,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"EnumerationValueDefinition\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/ExternalIdentifierMapDao.cs
+++ b/CDP4Orm/AutoGenDao/ExternalIdentifierMapDao.cs
@@ -280,7 +280,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ExternalIdentifierMap\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"ExternalFormat\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :externalFormat, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :externalFormat, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = externalIdentifierMap.Iid;

--- a/CDP4Orm/AutoGenDao/FileRevisionDao.cs
+++ b/CDP4Orm/AutoGenDao/FileRevisionDao.cs
@@ -354,7 +354,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"FileRevision\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"ContainingFolder\", \"Creator\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :containingFolder, :creator)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :containingFolder, :creator)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = fileRevision.Iid;
@@ -440,8 +440,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"FileRevision_FileType\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.Append(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.Append(" = :reorderSequence");
                 sqlBuilder.Append(" WHERE \"FileRevision\" = :fileRevision");
                 sqlBuilder.Append(" AND \"FileType\" = :fileType");
                 sqlBuilder.Append(" AND \"Sequence\" = :sequence;");

--- a/CDP4Orm/AutoGenDao/FileStoreDao.cs
+++ b/CDP4Orm/AutoGenDao/FileStoreDao.cs
@@ -134,7 +134,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"FileStore\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = fileStore.Iid;

--- a/CDP4Orm/AutoGenDao/FileTypeDao.cs
+++ b/CDP4Orm/AutoGenDao/FileTypeDao.cs
@@ -356,7 +356,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"FileType\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = fileType.Iid;
@@ -403,7 +403,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"FileType\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/FolderDao.cs
+++ b/CDP4Orm/AutoGenDao/FolderDao.cs
@@ -265,7 +265,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Folder\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"ContainingFolder\", \"Creator\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :containingFolder, :creator, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :containingFolder, :creator, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = folder.Iid;

--- a/CDP4Orm/AutoGenDao/GenericAnnotationDao.cs
+++ b/CDP4Orm/AutoGenDao/GenericAnnotationDao.cs
@@ -134,8 +134,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"GenericAnnotation\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = genericAnnotation.Iid;

--- a/CDP4Orm/AutoGenDao/GlossaryDao.cs
+++ b/CDP4Orm/AutoGenDao/GlossaryDao.cs
@@ -349,7 +349,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Glossary\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = glossary.Iid;
@@ -396,7 +396,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Glossary\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/GoalDao.cs
+++ b/CDP4Orm/AutoGenDao/GoalDao.cs
@@ -330,8 +330,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Goal\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = goal.Iid;

--- a/CDP4Orm/AutoGenDao/HyperLinkDao.cs
+++ b/CDP4Orm/AutoGenDao/HyperLinkDao.cs
@@ -267,7 +267,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"HyperLink\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = hyperLink.Iid;

--- a/CDP4Orm/AutoGenDao/IdCorrespondenceDao.cs
+++ b/CDP4Orm/AutoGenDao/IdCorrespondenceDao.cs
@@ -259,7 +259,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"IdCorrespondence\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = idCorrespondence.Iid;

--- a/CDP4Orm/AutoGenDao/IterationDao.cs
+++ b/CDP4Orm/AutoGenDao/IterationDao.cs
@@ -274,7 +274,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Iteration\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"DefaultOption\", \"IterationSetup\", \"TopElement\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :defaultOption, :iterationSetup, :topElement)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :defaultOption, :iterationSetup, :topElement)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iteration.Iid;

--- a/CDP4Orm/AutoGenDao/IterationSetupDao.cs
+++ b/CDP4Orm/AutoGenDao/IterationSetupDao.cs
@@ -293,7 +293,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"IterationSetup\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"SourceIterationSetup\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :sourceIterationSetup)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :sourceIterationSetup)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iterationSetup.Iid;

--- a/CDP4Orm/AutoGenDao/LogarithmicScaleDao.cs
+++ b/CDP4Orm/AutoGenDao/LogarithmicScaleDao.cs
@@ -335,7 +335,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"LogarithmicScale\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"ReferenceQuantityKind\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :referenceQuantityKind)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :referenceQuantityKind)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = logarithmicScale.Iid;

--- a/CDP4Orm/AutoGenDao/MeasurementScaleDao.cs
+++ b/CDP4Orm/AutoGenDao/MeasurementScaleDao.cs
@@ -147,7 +147,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"MeasurementScale\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Unit\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :unit)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :unit)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = measurementScale.Iid;
@@ -195,7 +195,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"MeasurementScale\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/MeasurementUnitDao.cs
+++ b/CDP4Orm/AutoGenDao/MeasurementUnitDao.cs
@@ -132,7 +132,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"MeasurementUnit\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = measurementUnit.Iid;
@@ -179,7 +179,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"MeasurementUnit\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/ModelLogEntryDao.cs
+++ b/CDP4Orm/AutoGenDao/ModelLogEntryDao.cs
@@ -407,7 +407,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ModelLogEntry\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Author\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :author)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :author)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = modelLogEntry.Iid;

--- a/CDP4Orm/AutoGenDao/ModelReferenceDataLibraryDao.cs
+++ b/CDP4Orm/AutoGenDao/ModelReferenceDataLibraryDao.cs
@@ -261,8 +261,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ModelReferenceDataLibrary\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = modelReferenceDataLibrary.Iid;

--- a/CDP4Orm/AutoGenDao/ModellingAnnotationItemDao.cs
+++ b/CDP4Orm/AutoGenDao/ModellingAnnotationItemDao.cs
@@ -264,7 +264,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ModellingAnnotationItem\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = modellingAnnotationItem.Iid;

--- a/CDP4Orm/AutoGenDao/ModellingThingReferenceDao.cs
+++ b/CDP4Orm/AutoGenDao/ModellingThingReferenceDao.cs
@@ -240,8 +240,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ModellingThingReference\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = modellingThingReference.Iid;

--- a/CDP4Orm/AutoGenDao/MultiRelationshipRuleDao.cs
+++ b/CDP4Orm/AutoGenDao/MultiRelationshipRuleDao.cs
@@ -363,7 +363,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"MultiRelationshipRule\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"RelationshipCategory\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :relationshipCategory)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :relationshipCategory)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = multiRelationshipRule.Iid;

--- a/CDP4Orm/AutoGenDao/NaturalLanguageDao.cs
+++ b/CDP4Orm/AutoGenDao/NaturalLanguageDao.cs
@@ -267,7 +267,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"NaturalLanguage\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = naturalLanguage.Iid;

--- a/CDP4Orm/AutoGenDao/NestedElementDao.cs
+++ b/CDP4Orm/AutoGenDao/NestedElementDao.cs
@@ -337,7 +337,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"NestedElement\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"RootElement\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :rootElement)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :rootElement)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = nestedElement.Iid;
@@ -422,8 +422,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"NestedElement_ElementUsage\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.Append(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.Append(" = :reorderSequence");
                 sqlBuilder.Append(" WHERE \"NestedElement\" = :nestedElement");
                 sqlBuilder.Append(" AND \"ElementUsage\" = :elementUsage");
                 sqlBuilder.Append(" AND \"Sequence\" = :sequence;");

--- a/CDP4Orm/AutoGenDao/NestedParameterDao.cs
+++ b/CDP4Orm/AutoGenDao/NestedParameterDao.cs
@@ -273,7 +273,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"NestedParameter\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"ActualState\", \"AssociatedParameter\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :actualState, :associatedParameter, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :actualState, :associatedParameter, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = nestedParameter.Iid;

--- a/CDP4Orm/AutoGenDao/NotExpressionDao.cs
+++ b/CDP4Orm/AutoGenDao/NotExpressionDao.cs
@@ -234,8 +234,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"NotExpression\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Term\")");
-                    sqlBuilder.AppendFormat(" = (:term)");
+                    sqlBuilder.AppendFormat(" SET \"Term\"");
+                    sqlBuilder.AppendFormat(" = :term");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = notExpression.Iid;

--- a/CDP4Orm/AutoGenDao/NoteDao.cs
+++ b/CDP4Orm/AutoGenDao/NoteDao.cs
@@ -222,7 +222,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Note\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = note.Iid;
@@ -263,8 +263,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Note\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/OptionDao.cs
+++ b/CDP4Orm/AutoGenDao/OptionDao.cs
@@ -335,8 +335,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Option\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = option.Iid;
@@ -375,8 +375,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Option\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/OrdinalScaleDao.cs
+++ b/CDP4Orm/AutoGenDao/OrdinalScaleDao.cs
@@ -315,8 +315,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"OrdinalScale\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = ordinalScale.Iid;

--- a/CDP4Orm/AutoGenDao/OrganizationDao.cs
+++ b/CDP4Orm/AutoGenDao/OrganizationDao.cs
@@ -267,7 +267,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Organization\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = organization.Iid;
@@ -314,7 +314,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Organization\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/OwnedStyleDao.cs
+++ b/CDP4Orm/AutoGenDao/OwnedStyleDao.cs
@@ -297,8 +297,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"OwnedStyle\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = ownedStyle.Iid;

--- a/CDP4Orm/AutoGenDao/PageDao.cs
+++ b/CDP4Orm/AutoGenDao/PageDao.cs
@@ -356,7 +356,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Page\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = page.Iid;
@@ -397,8 +397,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Page\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/ParameterBaseDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterBaseDao.cs
@@ -136,7 +136,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterBase\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Group\", \"Owner\", \"ParameterType\", \"Scale\", \"StateDependence\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :group, :owner, :parameterType, :scale, :stateDependence)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :group, :owner, :parameterType, :scale, :stateDependence)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterBase.Iid;

--- a/CDP4Orm/AutoGenDao/ParameterDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterDao.cs
@@ -274,7 +274,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Parameter\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"RequestedBy\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :requestedBy)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :requestedBy)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameter.Iid;

--- a/CDP4Orm/AutoGenDao/ParameterGroupDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterGroupDao.cs
@@ -253,7 +253,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterGroup\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"ContainingGroup\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :containingGroup)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :containingGroup)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterGroup.Iid;

--- a/CDP4Orm/AutoGenDao/ParameterSubscriptionDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterSubscriptionDao.cs
@@ -235,8 +235,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterSubscription\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterSubscription.Iid;

--- a/CDP4Orm/AutoGenDao/ParameterSubscriptionValueSetDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterSubscriptionValueSetDao.cs
@@ -261,7 +261,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterSubscriptionValueSet\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"SubscribedValueSet\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :subscribedValueSet)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :subscribedValueSet)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterSubscriptionValueSet.Iid;

--- a/CDP4Orm/AutoGenDao/ParameterTypeComponentDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterTypeComponentDao.cs
@@ -259,7 +259,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterTypeComponent\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"ParameterType\", \"Scale\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :parameterType, :scale)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :parameterType, :scale)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterTypeComponent.Iid;
@@ -301,8 +301,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterTypeComponent\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/ParameterTypeDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterTypeDao.cs
@@ -215,7 +215,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterType\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterType.Iid;
@@ -262,7 +262,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterType\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/ParameterValueDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterValueDao.cs
@@ -133,7 +133,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterValue\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"ParameterType\", \"Scale\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :parameterType, :scale)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :parameterType, :scale)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterValue.Iid;

--- a/CDP4Orm/AutoGenDao/ParameterValueSetBaseDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterValueSetBaseDao.cs
@@ -143,7 +143,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterValueSetBase\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"ActualOption\", \"ActualState\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :actualOption, :actualState)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :actualOption, :actualState)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterValueSetBase.Iid;

--- a/CDP4Orm/AutoGenDao/ParameterValueSetDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterValueSetDao.cs
@@ -271,8 +271,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterValueSet\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterValueSet.Iid;

--- a/CDP4Orm/AutoGenDao/ParameterizedCategoryRuleDao.cs
+++ b/CDP4Orm/AutoGenDao/ParameterizedCategoryRuleDao.cs
@@ -337,8 +337,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParameterizedCategoryRule\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Category\")");
-                    sqlBuilder.AppendFormat(" = (:category)");
+                    sqlBuilder.AppendFormat(" SET \"Category\"");
+                    sqlBuilder.AppendFormat(" = :category");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = parameterizedCategoryRule.Iid;

--- a/CDP4Orm/AutoGenDao/ParametricConstraintDao.cs
+++ b/CDP4Orm/AutoGenDao/ParametricConstraintDao.cs
@@ -281,8 +281,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParametricConstraint\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/ParticipantDao.cs
+++ b/CDP4Orm/AutoGenDao/ParticipantDao.cs
@@ -339,7 +339,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Participant\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Person\", \"Role\", \"SelectedDomain\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :person, :role, :selectedDomain)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :person, :role, :selectedDomain)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = participant.Iid;

--- a/CDP4Orm/AutoGenDao/ParticipantPermissionDao.cs
+++ b/CDP4Orm/AutoGenDao/ParticipantPermissionDao.cs
@@ -267,7 +267,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParticipantPermission\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = participantPermission.Iid;
@@ -314,7 +314,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParticipantPermission\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/ParticipantRoleDao.cs
+++ b/CDP4Orm/AutoGenDao/ParticipantRoleDao.cs
@@ -267,7 +267,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParticipantRole\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = participantRole.Iid;
@@ -314,7 +314,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ParticipantRole\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/PersonDao.cs
+++ b/CDP4Orm/AutoGenDao/PersonDao.cs
@@ -312,7 +312,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Person\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"DefaultDomain\", \"DefaultEmailAddress\", \"DefaultTelephoneNumber\", \"Organization\", \"Role\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :defaultDomain, :defaultEmailAddress, :defaultTelephoneNumber, :organization, :role)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :defaultDomain, :defaultEmailAddress, :defaultTelephoneNumber, :organization, :role)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = person.Iid;
@@ -364,7 +364,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Person\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/PersonPermissionDao.cs
+++ b/CDP4Orm/AutoGenDao/PersonPermissionDao.cs
@@ -267,7 +267,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"PersonPermission\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = personPermission.Iid;
@@ -314,7 +314,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"PersonPermission\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/PersonRoleDao.cs
+++ b/CDP4Orm/AutoGenDao/PersonRoleDao.cs
@@ -267,7 +267,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"PersonRole\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = personRole.Iid;
@@ -314,7 +314,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"PersonRole\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/PointDao.cs
+++ b/CDP4Orm/AutoGenDao/PointDao.cs
@@ -269,7 +269,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Point\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = point.Iid;
@@ -309,8 +309,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Point\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/PossibleFiniteStateDao.cs
+++ b/CDP4Orm/AutoGenDao/PossibleFiniteStateDao.cs
@@ -252,8 +252,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"PossibleFiniteState\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = possibleFiniteState.Iid;
@@ -292,8 +292,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"PossibleFiniteState\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/PrefixedUnitDao.cs
+++ b/CDP4Orm/AutoGenDao/PrefixedUnitDao.cs
@@ -244,8 +244,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"PrefixedUnit\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Prefix\")");
-                    sqlBuilder.AppendFormat(" = (:prefix)");
+                    sqlBuilder.AppendFormat(" SET \"Prefix\"");
+                    sqlBuilder.AppendFormat(" = :prefix");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = prefixedUnit.Iid;

--- a/CDP4Orm/AutoGenDao/PublicationDao.cs
+++ b/CDP4Orm/AutoGenDao/PublicationDao.cs
@@ -378,7 +378,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Publication\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = publication.Iid;

--- a/CDP4Orm/AutoGenDao/QuantityKindDao.cs
+++ b/CDP4Orm/AutoGenDao/QuantityKindDao.cs
@@ -213,7 +213,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"QuantityKind\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"DefaultScale\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :defaultScale)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :defaultScale)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = quantityKind.Iid;

--- a/CDP4Orm/AutoGenDao/QuantityKindFactorDao.cs
+++ b/CDP4Orm/AutoGenDao/QuantityKindFactorDao.cs
@@ -257,7 +257,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"QuantityKindFactor\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"QuantityKind\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :quantityKind)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :quantityKind)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = quantityKindFactor.Iid;
@@ -298,8 +298,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"QuantityKindFactor\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/ReferenceDataLibraryDao.cs
+++ b/CDP4Orm/AutoGenDao/ReferenceDataLibraryDao.cs
@@ -246,8 +246,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ReferenceDataLibrary\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"RequiredRdl\")");
-                    sqlBuilder.AppendFormat(" = (:requiredRdl)");
+                    sqlBuilder.AppendFormat(" SET \"RequiredRdl\"");
+                    sqlBuilder.AppendFormat(" = :requiredRdl");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = referenceDataLibrary.Iid;
@@ -330,8 +330,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ReferenceDataLibrary_BaseQuantityKind\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.Append(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.Append(" = :reorderSequence");
                 sqlBuilder.Append(" WHERE \"ReferenceDataLibrary\" = :referenceDataLibrary");
                 sqlBuilder.Append(" AND \"BaseQuantityKind\" = :baseQuantityKind");
                 sqlBuilder.Append(" AND \"Sequence\" = :sequence;");

--- a/CDP4Orm/AutoGenDao/ReferenceSourceDao.cs
+++ b/CDP4Orm/AutoGenDao/ReferenceSourceDao.cs
@@ -392,7 +392,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ReferenceSource\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"PublishedIn\", \"Publisher\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :publishedIn, :publisher)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :publishedIn, :publisher)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = referenceSource.Iid;
@@ -441,7 +441,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ReferenceSource\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/ReferencerRuleDao.cs
+++ b/CDP4Orm/AutoGenDao/ReferencerRuleDao.cs
@@ -363,7 +363,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ReferencerRule\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"ReferencingCategory\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :referencingCategory)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :referencingCategory)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = referencerRule.Iid;

--- a/CDP4Orm/AutoGenDao/RelationalExpressionDao.cs
+++ b/CDP4Orm/AutoGenDao/RelationalExpressionDao.cs
@@ -262,7 +262,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RelationalExpression\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"ParameterType\", \"Scale\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :parameterType, :scale)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :parameterType, :scale)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = relationalExpression.Iid;

--- a/CDP4Orm/AutoGenDao/RelationshipParameterValueDao.cs
+++ b/CDP4Orm/AutoGenDao/RelationshipParameterValueDao.cs
@@ -241,8 +241,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RelationshipParameterValue\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = relationshipParameterValue.Iid;

--- a/CDP4Orm/AutoGenDao/RequirementDao.cs
+++ b/CDP4Orm/AutoGenDao/RequirementDao.cs
@@ -353,7 +353,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Requirement\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Group\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :group)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :group)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = requirement.Iid;
@@ -401,7 +401,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Requirement\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/RequirementsContainerDao.cs
+++ b/CDP4Orm/AutoGenDao/RequirementsContainerDao.cs
@@ -201,8 +201,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RequirementsContainer\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Owner\")");
-                    sqlBuilder.AppendFormat(" = (:owner)");
+                    sqlBuilder.AppendFormat(" SET \"Owner\"");
+                    sqlBuilder.AppendFormat(" = :owner");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = requirementsContainer.Iid;

--- a/CDP4Orm/AutoGenDao/RequirementsContainerParameterValueDao.cs
+++ b/CDP4Orm/AutoGenDao/RequirementsContainerParameterValueDao.cs
@@ -241,8 +241,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RequirementsContainerParameterValue\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = requirementsContainerParameterValue.Iid;

--- a/CDP4Orm/AutoGenDao/RequirementsGroupDao.cs
+++ b/CDP4Orm/AutoGenDao/RequirementsGroupDao.cs
@@ -252,8 +252,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RequirementsGroup\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = requirementsGroup.Iid;

--- a/CDP4Orm/AutoGenDao/RequirementsSpecificationDao.cs
+++ b/CDP4Orm/AutoGenDao/RequirementsSpecificationDao.cs
@@ -271,7 +271,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RequirementsSpecification\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = requirementsSpecification.Iid;
@@ -318,7 +318,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RequirementsSpecification\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/RuleDao.cs
+++ b/CDP4Orm/AutoGenDao/RuleDao.cs
@@ -132,7 +132,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Rule\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = rule.Iid;
@@ -179,7 +179,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Rule\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/RuleVerificationDao.cs
+++ b/CDP4Orm/AutoGenDao/RuleVerificationDao.cs
@@ -142,7 +142,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RuleVerification\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = ruleVerification.Iid;
@@ -182,8 +182,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RuleVerification\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/RuleViolationDao.cs
+++ b/CDP4Orm/AutoGenDao/RuleViolationDao.cs
@@ -335,7 +335,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"RuleViolation\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = ruleViolation.Iid;

--- a/CDP4Orm/AutoGenDao/ScaleReferenceQuantityValueDao.cs
+++ b/CDP4Orm/AutoGenDao/ScaleReferenceQuantityValueDao.cs
@@ -253,7 +253,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ScaleReferenceQuantityValue\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Scale\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :scale)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :scale)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = scaleReferenceQuantityValue.Iid;

--- a/CDP4Orm/AutoGenDao/ScaleValueDefinitionDao.cs
+++ b/CDP4Orm/AutoGenDao/ScaleValueDefinitionDao.cs
@@ -266,7 +266,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ScaleValueDefinition\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = scaleValueDefinition.Iid;

--- a/CDP4Orm/AutoGenDao/SectionDao.cs
+++ b/CDP4Orm/AutoGenDao/SectionDao.cs
@@ -356,7 +356,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Section\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Owner\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :owner)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :owner)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = section.Iid;
@@ -397,8 +397,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Section\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/SharedStyleDao.cs
+++ b/CDP4Orm/AutoGenDao/SharedStyleDao.cs
@@ -297,8 +297,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"SharedStyle\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = sharedStyle.Iid;

--- a/CDP4Orm/AutoGenDao/SimpleParameterValueDao.cs
+++ b/CDP4Orm/AutoGenDao/SimpleParameterValueDao.cs
@@ -255,7 +255,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"SimpleParameterValue\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"ParameterType\", \"Scale\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :parameterType, :scale)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :parameterType, :scale)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = simpleParameterValue.Iid;

--- a/CDP4Orm/AutoGenDao/SimpleParameterizableThingDao.cs
+++ b/CDP4Orm/AutoGenDao/SimpleParameterizableThingDao.cs
@@ -120,8 +120,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"SimpleParameterizableThing\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Owner\")");
-                    sqlBuilder.AppendFormat(" = (:owner)");
+                    sqlBuilder.AppendFormat(" SET \"Owner\"");
+                    sqlBuilder.AppendFormat(" = :owner");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = simpleParameterizableThing.Iid;

--- a/CDP4Orm/AutoGenDao/SiteDirectoryDao.cs
+++ b/CDP4Orm/AutoGenDao/SiteDirectoryDao.cs
@@ -287,7 +287,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"SiteDirectory\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"DefaultParticipantRole\", \"DefaultPersonRole\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :defaultParticipantRole, :defaultPersonRole)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :defaultParticipantRole, :defaultPersonRole)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = siteDirectory.Iid;

--- a/CDP4Orm/AutoGenDao/SiteDirectoryThingReferenceDao.cs
+++ b/CDP4Orm/AutoGenDao/SiteDirectoryThingReferenceDao.cs
@@ -240,8 +240,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"SiteDirectoryThingReference\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = siteDirectoryThingReference.Iid;

--- a/CDP4Orm/AutoGenDao/SiteLogEntryDao.cs
+++ b/CDP4Orm/AutoGenDao/SiteLogEntryDao.cs
@@ -407,7 +407,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"SiteLogEntry\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Author\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :author)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :author)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = siteLogEntry.Iid;

--- a/CDP4Orm/AutoGenDao/SiteReferenceDataLibraryDao.cs
+++ b/CDP4Orm/AutoGenDao/SiteReferenceDataLibraryDao.cs
@@ -279,7 +279,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"SiteReferenceDataLibrary\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = siteReferenceDataLibrary.Iid;
@@ -326,7 +326,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"SiteReferenceDataLibrary\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/SpecializedQuantityKindDao.cs
+++ b/CDP4Orm/AutoGenDao/SpecializedQuantityKindDao.cs
@@ -270,8 +270,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"SpecializedQuantityKind\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"General\")");
-                    sqlBuilder.AppendFormat(" = (:general)");
+                    sqlBuilder.AppendFormat(" SET \"General\"");
+                    sqlBuilder.AppendFormat(" = :general");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = specializedQuantityKind.Iid;

--- a/CDP4Orm/AutoGenDao/StakeHolderValueMapDao.cs
+++ b/CDP4Orm/AutoGenDao/StakeHolderValueMapDao.cs
@@ -511,8 +511,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"StakeHolderValueMap\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = stakeHolderValueMap.Iid;

--- a/CDP4Orm/AutoGenDao/StakeholderDao.cs
+++ b/CDP4Orm/AutoGenDao/StakeholderDao.cs
@@ -375,8 +375,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Stakeholder\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = stakeholder.Iid;

--- a/CDP4Orm/AutoGenDao/StakeholderValueDao.cs
+++ b/CDP4Orm/AutoGenDao/StakeholderValueDao.cs
@@ -330,8 +330,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"StakeholderValue\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = stakeholderValue.Iid;

--- a/CDP4Orm/AutoGenDao/TelephoneNumberDao.cs
+++ b/CDP4Orm/AutoGenDao/TelephoneNumberDao.cs
@@ -334,7 +334,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"TelephoneNumber\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = telephoneNumber.Iid;

--- a/CDP4Orm/AutoGenDao/TermDao.cs
+++ b/CDP4Orm/AutoGenDao/TermDao.cs
@@ -266,7 +266,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Term\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = term.Iid;
@@ -313,7 +313,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Term\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/TextualNoteDao.cs
+++ b/CDP4Orm/AutoGenDao/TextualNoteDao.cs
@@ -277,8 +277,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"TextualNote\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = textualNote.Iid;

--- a/CDP4Orm/AutoGenDao/ThingDao.cs
+++ b/CDP4Orm/AutoGenDao/ThingDao.cs
@@ -255,8 +255,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"Thing\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = thing.Iid;

--- a/CDP4Orm/AutoGenDao/ThingReferenceDao.cs
+++ b/CDP4Orm/AutoGenDao/ThingReferenceDao.cs
@@ -132,7 +132,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ThingReference\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"ReferencedThing\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :referencedThing)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :referencedThing)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = thingReference.Iid;

--- a/CDP4Orm/AutoGenDao/TopContainerDao.cs
+++ b/CDP4Orm/AutoGenDao/TopContainerDao.cs
@@ -130,8 +130,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"TopContainer\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary)");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\"");
+                    sqlBuilder.AppendFormat(" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = topContainer.Iid;

--- a/CDP4Orm/AutoGenDao/UnitFactorDao.cs
+++ b/CDP4Orm/AutoGenDao/UnitFactorDao.cs
@@ -257,7 +257,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"UnitFactor\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\", \"Unit\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container, :unit)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container, :unit)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = unitFactor.Iid;
@@ -298,8 +298,8 @@ namespace CDP4Orm.Dao
             {
                 var sqlBuilder = new System.Text.StringBuilder();
                 sqlBuilder.AppendFormat("UPDATE \"{0}\".\"UnitFactor\"", partition);
-                sqlBuilder.AppendFormat(" SET (\"Sequence\")");
-                sqlBuilder.AppendFormat(" = (:reorderSequence)");
+                sqlBuilder.AppendFormat(" SET \"Sequence\"");
+                sqlBuilder.AppendFormat(" = :reorderSequence");
                 sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid");
                 sqlBuilder.AppendFormat(" AND \"Sequence\" = :sequence;");
 

--- a/CDP4Orm/AutoGenDao/UnitPrefixDao.cs
+++ b/CDP4Orm/AutoGenDao/UnitPrefixDao.cs
@@ -274,7 +274,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"UnitPrefix\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = unitPrefix.Iid;
@@ -321,7 +321,7 @@ namespace CDP4Orm.Dao
                                 { "IsDeprecated", "true" }
                             };
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"UnitPrefix\"", partition);
-                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = \"ValueTypeDictionary\" || :valueTypeDictionary");
+                    sqlBuilder.AppendFormat(" SET \"ValueTypeDictionary\" = :valueTypeDictionary");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = iid;
                     command.Parameters.Add("valueTypeDictionary", NpgsqlDbType.Hstore).Value = valueTypeDictionaryContents;

--- a/CDP4Orm/AutoGenDao/UserPreferenceDao.cs
+++ b/CDP4Orm/AutoGenDao/UserPreferenceDao.cs
@@ -259,7 +259,7 @@ namespace CDP4Orm.Dao
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"UserPreference\"", partition);
                     sqlBuilder.AppendFormat(" SET (\"ValueTypeDictionary\", \"Container\")");
-                    sqlBuilder.AppendFormat(" = (\"ValueTypeDictionary\" || :valueTypeDictionary, :container)");
+                    sqlBuilder.AppendFormat(" = (:valueTypeDictionary, :container)");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = userPreference.Iid;

--- a/CDP4Orm/AutoGenDao/UserRuleVerificationDao.cs
+++ b/CDP4Orm/AutoGenDao/UserRuleVerificationDao.cs
@@ -253,8 +253,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"UserRuleVerification\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Rule\")");
-                    sqlBuilder.AppendFormat(" = (:rule)");
+                    sqlBuilder.AppendFormat(" SET \"Rule\"");
+                    sqlBuilder.AppendFormat(" = :rule");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = userRuleVerification.Iid;

--- a/CDP4Orm/AutoGenDao/ValueGroupDao.cs
+++ b/CDP4Orm/AutoGenDao/ValueGroupDao.cs
@@ -330,8 +330,8 @@ namespace CDP4Orm.Dao
                 {
                     var sqlBuilder = new System.Text.StringBuilder();
                     sqlBuilder.AppendFormat("UPDATE \"{0}\".\"ValueGroup\"", partition);
-                    sqlBuilder.AppendFormat(" SET (\"Container\")");
-                    sqlBuilder.AppendFormat(" = (:container)");
+                    sqlBuilder.AppendFormat(" SET \"Container\"");
+                    sqlBuilder.AppendFormat(" = :container");
                     sqlBuilder.AppendFormat(" WHERE \"Iid\" = :iid;");
 
                     command.Parameters.Add("iid", NpgsqlDbType.Uuid).Value = valueGroup.Iid;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
code generated DAO classes have been updated to no longer make use of multi-column UPDATE statements when only one column is updated. PostgreSQL 9.6.x was lenient on using multi-column type statements (using brackets `()` ) when only one column was being updated, PostgreSQL 10-12 are not. This is updated in this PR.

<!-- Thanks for contributing to CDP4 Web Services! -->