### PR TITLE
Fixes GH98: timestamps in revision query parameters

### DIFF
--- a/CDP4Orm/Dao/Revision/IRevisionDao.cs
+++ b/CDP4Orm/Dao/Revision/IRevisionDao.cs
@@ -51,6 +51,20 @@ namespace CDP4Orm.Dao.Revision
         IEnumerable<RevisionInfo> ReadCurrentRevisionChanges(NpgsqlTransaction transaction, string partition, int revision);
 
         /// <summary>
+        /// Retrieves data from the RevisionRegistry table in the specific partition.
+        /// </summary>
+        /// <param name="transaction">
+        /// The current transaction to the database.
+        /// </param>
+        /// <param name="partition">
+        /// The database partition (schema) where the requested resource is stored.
+        /// </param>
+        /// <returns>
+        /// List of instances of <see cref="RevisionRegistryInfo"/>.
+        /// </returns>
+        IEnumerable<RevisionRegistryInfo> ReadRevisionRegistry(NpgsqlTransaction transaction, string partition);
+
+        /// <summary>
         /// Read the revisions of a <see cref="Thing"/>
         /// </summary>
         /// <param name="transaction">The current transaction to the database.</param>

--- a/CDP4Orm/Dao/Revision/RevisionDao.cs
+++ b/CDP4Orm/Dao/Revision/RevisionDao.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RevisionDao.cs" company="RHEA System S.A.">
-//   Copyright (c) 2017-2018 System RHEA System S.A.
+//   Copyright (c) 2017-2020 System RHEA System S.A.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -88,6 +88,23 @@ namespace CDP4Orm.Dao.Revision
         /// Gets or sets the <see cref="IResolveDao"/> that retrieve metadata of an object
         /// </summary>
         public IResolveDao ResolveDao { get; set; }
+
+        /// <summary>
+        /// Retrieves data from the RevisionRegistry table in the specific partition.
+        /// </summary>
+        /// <param name="transaction">
+        /// The current transaction to the database.
+        /// </param>
+        /// <param name="partition">
+        /// The database partition (schema) where the requested resource is stored.
+        /// </param>
+        /// <returns>
+        /// List of instances of <see cref="RevisionRegistryInfo"/>.
+        /// </returns>
+        public IEnumerable<RevisionRegistryInfo> ReadRevisionRegistry(NpgsqlTransaction transaction, string partition)
+        {
+            return this.InternalGetRevisionRegistryInfo(transaction, partition);
+        }
 
         /// <summary>
         /// Retrieves the data that was changed after the indicated revision.
@@ -179,7 +196,7 @@ namespace CDP4Orm.Dao.Revision
             var sqlQuery = string.Format(
                 "SELECT \"{0}\" FROM \"{1}\".\"{2}\" WHERE \"{3}\" = :iid AND \"{4}\" >= :fromrevision AND \"{4}\" <= :torevision",
                 JsonColumnName,
-                partition,
+                resolveInfo.Partition,
                 revisionTableName,
                 IidKey,
                 RevisionColumnName);
@@ -332,6 +349,54 @@ namespace CDP4Orm.Dao.Revision
 
             // make sure to wrap the yield result as list; the internal iterator yield response otherwise (somehow) sets the transaction to an invalid state. 
             return this.ReadEngineeringModelRevisions(transaction, partition, revision, comparator).ToList();
+        }
+
+        /// <summary>
+        /// Read the entries in the RevisionsRegistry table of specific partition
+        /// </summary>
+        /// <param name="transaction">The current transaction to the database.</param>
+        /// <param name="partition">The database partition (schema) where the requested resource is stored.</param>
+        /// <returns>The collection of revised <see cref="Thing"/></returns>
+        private IEnumerable<RevisionRegistryInfo> InternalGetRevisionRegistryInfo(NpgsqlTransaction transaction, string partition)
+        {
+            var sqlQuery = $"SELECT \"Revision\", \"Instant\", \"Actor\" FROM \"{partition}\".\"RevisionRegistry\"";
+
+            using (var command = new NpgsqlCommand(sqlQuery, transaction.Connection, transaction))
+            {
+                // log the sql command 
+                this.CommandLogger.Log(command);
+
+                using (var reader = command.ExecuteReader())
+                {
+                    return this.MapToRevisionRegistryInfoList(reader).ToList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The mapping from a database record to <see cref="IEnumerable{RevisionRegistryInfo}"/> object.
+        /// </summary>
+        /// <param name="reader">
+        /// An instance of the SQL reader.
+        /// </param>
+        /// <returns>
+        /// Enumerable of <see cref="RevisionRegistryInfo"/>.
+        /// </returns>
+        private IEnumerable<RevisionRegistryInfo> MapToRevisionRegistryInfoList(NpgsqlDataReader reader)
+        {
+            while (reader.Read())
+            {
+                var revision = reader["Revision"];
+                var instant = reader["Instant"];
+                var actor = reader["Actor"];
+
+                yield return new RevisionRegistryInfo
+                {
+                    Revision = (int?) revision ?? 0,
+                    Instant = (DateTime?) instant ?? DateTime.MinValue,
+                    Actor = actor == DBNull.Value ? Guid.Empty : (Guid) actor
+                };
+            }
         }
 
         /// <summary>

--- a/CDP4Orm/Dao/Revision/RevisionRegistryInfo.cs
+++ b/CDP4Orm/Dao/Revision/RevisionRegistryInfo.cs
@@ -1,0 +1,31 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RevisionRegistryInfo.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Orm.Dao.Revision
+{
+    using System;
+
+    /// <summary>
+    /// Holds information about a single RevisionRegistry Entry
+    /// </summary>
+    public class RevisionRegistryInfo
+    {
+        /// <summary>
+        /// Gets or sets the revision number
+        /// </summary>
+        public int Revision { get; set; }
+
+        /// <summary>
+        /// Gets or sets the datetime on which the revision was created
+        /// </summary>
+        public DateTime Instant { get; set; }
+
+        /// <summary>
+        /// Gets or sets the id of the person that created the revision
+        /// </summary>
+        public Guid Actor { get; set; }
+    }
+}

--- a/CDP4WebServices.API.Tests/Services/Revision/RevisionResolverTestFixture.cs
+++ b/CDP4WebServices.API.Tests/Services/Revision/RevisionResolverTestFixture.cs
@@ -1,0 +1,142 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RevisionResolverTestFixture.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// <summary>
+//   This is the RevisionResolver test class
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4WebServices.API.Tests
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Orm.Dao.Revision;
+
+    using CDP4WebServices.API.Services;
+
+    using Moq;
+
+    using Npgsql;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Test fixture for the <see cref="RevisionResolver"/> class
+    /// </summary>
+    [TestFixture]
+    public class RevisionResolverTestFixture
+    {
+        private RevisionResolver revisionResolver;
+        private Mock<IRevisionDao> revisionDao;
+        private RevisionRegistryInfo revision1;
+        private RevisionRegistryInfo revision2;
+        private RevisionRegistryInfo revision3;
+        private RevisionRegistryInfo revision4;
+        private RevisionRegistryInfo revision5;
+        private static readonly DateTime timestamp1 = new DateTime(2020, 1, 1);
+        private static readonly DateTime timestamp2 = new DateTime(2020, 1, 2);
+        private static readonly DateTime timestamp3 = new DateTime(2020, 1, 2, 10, 0, 0);
+        private static readonly DateTime timestamp4 = new DateTime(2020, 1, 2, 14, 0, 0);
+        private static readonly DateTime timestamp5 = new DateTime(2020, 1, 3);
+
+        [SetUp]
+        public void TestSetup()
+        {
+            this.revisionDao = new Mock<IRevisionDao>();
+            this.revisionResolver = new RevisionResolver { RevisionDao = this.revisionDao.Object };
+
+            this.revision1 = new RevisionRegistryInfo
+            {
+                Actor = Guid.NewGuid(),
+                Instant = timestamp1,
+                Revision = 1
+            };
+
+            this.revision2 = new RevisionRegistryInfo
+            {
+                Actor = Guid.NewGuid(),
+                Instant = timestamp2,
+                Revision = 2
+            };
+
+            this.revision3 = new RevisionRegistryInfo
+            {
+                Actor = Guid.NewGuid(),
+                Instant = timestamp3,
+                Revision = 3
+            };
+
+            this.revision4 = new RevisionRegistryInfo
+            {
+                Actor = Guid.NewGuid(),
+                Instant = timestamp4,
+                Revision = 4
+            };
+
+            this.revision5 = new RevisionRegistryInfo
+            {
+                Actor = Guid.NewGuid(),
+                Instant = timestamp5,
+                Revision = 5
+            };
+
+            var revisionRegistryInfoList = new List<RevisionRegistryInfo>
+            {
+                this.revision1,
+                this.revision2,
+                this.revision3,
+                this.revision4,
+                this.revision5
+            };
+
+            this.revisionDao.Setup(x => x.ReadRevisionRegistry(It.IsAny<NpgsqlTransaction>(), It.IsAny<string>())).Returns(revisionRegistryInfoList);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(IntTestCases))]
+        public void VerifyThatCorrectRevisionsAreReturnedWhenRevisionNumbersAreUsed(int? fromRevision, int? toRevision, int checkFromRevision, int checkToRevision, int checkRevisionCount)
+        {
+            this.revisionResolver.TryResolve(It.IsAny<NpgsqlTransaction>(), "", fromRevision, toRevision, out var resolvedValues);
+
+            Assert.AreEqual(checkFromRevision, resolvedValues.FromRevision);
+            Assert.AreEqual(checkToRevision, resolvedValues.ToRevision);
+            Assert.AreEqual(checkRevisionCount, resolvedValues.RevisionRegistryInfoList.Count());
+        }
+
+        [Test]
+        [TestCaseSource(nameof(DateTimeTestCases))]
+        public void VerifyThatCorrectRevisionsAreReturnedWhenRevisionTimestampsAreUsed(DateTime? fromRevision, DateTime? toRevision, int checkFromRevision, int checkToRevision, int checkRevisionCount)
+        {
+            this.revisionResolver.TryResolve(It.IsAny<NpgsqlTransaction>(), "", fromRevision, toRevision, out var resolvedValues);
+
+            Assert.AreEqual(checkFromRevision, resolvedValues.FromRevision);
+            Assert.AreEqual(checkToRevision, resolvedValues.ToRevision);
+            Assert.AreEqual(checkRevisionCount, resolvedValues.RevisionRegistryInfoList.Count());
+        }
+
+        public static IEnumerable IntTestCases()
+        {
+            yield return new object[] { 1, 5, 1, 5, 5 };
+            yield return new object[] { 2, 4, 2, 4, 3 };
+            yield return new object[] { 2, null, 2, 5, 4 };
+            yield return new object[] { null, 3, 1, 3, 3 };
+            yield return new object[] { 0, int.MaxValue, 1, 5, 5 };
+        }
+
+        public static IEnumerable DateTimeTestCases()
+        {
+            yield return new object[] { timestamp1, timestamp5, 1, 5, 5 };
+            yield return new object[] { timestamp2, timestamp4, 2, 4, 3 };
+            yield return new object[] { timestamp2, null, 2, 5, 4 };
+            yield return new object[] { null, timestamp3, 1, 3, 3 };
+            yield return new object[] { timestamp1.AddDays(-1), timestamp2.AddDays(1), 1, 5, 5 };
+
+            yield return new object[] { timestamp1.AddSeconds(1), timestamp5.AddSeconds(-1), 2, 4, 3 };
+            yield return new object[] { timestamp2.AddSeconds(1), timestamp4.AddSeconds(-1), 3, 3, 1 };
+        }
+    }
+}

--- a/CDP4WebServices.API/Cdp4Bootstrapper.cs
+++ b/CDP4WebServices.API/Cdp4Bootstrapper.cs
@@ -171,6 +171,7 @@ namespace CDP4WebServices.API
                     // wireup revision read service provider
                     builder.RegisterTypeAsPropertyInjectedSingleton<RevisionDao, IRevisionDao>();
                     builder.RegisterTypeAsPropertyInjectedSingleton<RevisionService, IRevisionService>();
+                    builder.RegisterTypeAsPropertyInjectedSingleton<RevisionResolver, IRevisionResolver>();
 
                     // wireup cache service provider
                     builder.RegisterTypeAsPropertyInjectedSingleton<CacheDao, ICacheDao>();

--- a/CDP4WebServices.API/Modules/10-25/ApiBase.cs
+++ b/CDP4WebServices.API/Modules/10-25/ApiBase.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ApiBase.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016 RHEA System S.A.
+//   Copyright (c) 2016-2020 RHEA System S.A.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -146,6 +146,11 @@ namespace CDP4WebServices.API.Modules
         /// Gets or sets the revision service.
         /// </summary>
         public IRevisionService RevisionService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the revision resolver.
+        /// </summary>
+        public IRevisionResolver RevisionResolver { get; set; }
 
         /// <summary>
         /// Gets or sets the transaction manager for this request.
@@ -717,7 +722,7 @@ namespace CDP4WebServices.API.Modules
 
             var sw = new Stopwatch();
             sw.Start();
-            Logger.Debug("{0} start serialing dtos", requestToken);
+            Logger.Debug("{0} start serializing dtos", requestToken);
 
             this.JsonSerializer.Initialize(
                 this.RequestUtils.MetaInfoProvider,
@@ -725,7 +730,7 @@ namespace CDP4WebServices.API.Modules
             this.JsonSerializer.SerializeToStream(filteredDtos, stream);
             sw.Stop();
 
-            Logger.Debug("serialing dtos {0} in {1} [ms]", requestToken, sw.ElapsedMilliseconds);
+            Logger.Debug("serializing dtos {0} in {1} [ms]", requestToken, sw.ElapsedMilliseconds);
         }
 
         /// <summary>

--- a/CDP4WebServices.API/Services/Protocol/IQueryParameters.cs
+++ b/CDP4WebServices.API/Services/Protocol/IQueryParameters.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IQueryParameters.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016 RHEA System S.A.
+//   Copyright (c) 2016-2020 RHEA System S.A.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -44,14 +44,14 @@ namespace CDP4WebServices.API.Services.Protocol
         int RevisionNumber { get; set; }
 
         /// <summary>
-        /// Gets or sets the revision number from which the request is done
+        /// Gets or sets the revision number, or DateTime from which the request is done
         /// </summary>
-        int? RevisionFrom { get; set; }
+        object RevisionFrom { get; set; }
 
         /// <summary>
-        /// Gets or sets the revision number to which the request is done
+        /// Gets or sets the revision number, or DateTime to which the request is done
         /// </summary>
-        int? RevisionTo { get; set; }
+        object RevisionTo { get; set; }
 
         /// <summary>
         /// The validate query parameter.

--- a/CDP4WebServices.API/Services/Protocol/QueryParameters.cs
+++ b/CDP4WebServices.API/Services/Protocol/QueryParameters.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="QueryParameters.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016 RHEA System S.A.
+//   Copyright (c) 2016-2020 RHEA System S.A.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -8,6 +8,7 @@ namespace CDP4WebServices.API.Services.Protocol
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using CDP4Common.DTO;
 
@@ -128,14 +129,14 @@ namespace CDP4WebServices.API.Services.Protocol
         public int RevisionNumber { get; set; }
 
         /// <summary>
-        /// Gets or sets the revision number from which the request is done
+        /// Gets or sets the revision number, or DateTime from which the request is done
         /// </summary>
-        public int? RevisionFrom { get; set; }
+        public object RevisionFrom { get; set; }
 
         /// <summary>
-        /// Gets or sets the revision number to which the request is done
+        /// Gets or sets the revision number, or DateTime to which the request is done
         /// </summary>
-        public int? RevisionTo { get; set; }
+        public object RevisionTo { get; set; }
 
         /// <summary>
         /// The validate query parameter.
@@ -230,20 +231,24 @@ namespace CDP4WebServices.API.Services.Protocol
         /// <returns>
         /// The <see cref="bool"/>.
         /// </returns>
-        protected int? ProcessRevisionHistoryQueryParameter(Dictionary<string, object> queryParameters, string key)
+        protected object ProcessRevisionHistoryQueryParameter(Dictionary<string, object> queryParameters, string key)
         {
             if (!queryParameters.ContainsKey(key))
             {
                 return null;
             }
 
-            int revNumber;
-            if (!int.TryParse(queryParameters[key].ToString(), out revNumber))
+            if (int.TryParse(queryParameters[key].ToString(), out var revNumber))
             {
-                return null;
+                return revNumber;
             }
 
-            return revNumber;
+            if (!DateTime.TryParseExact(queryParameters[key].ToString(), "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var timestamp))
+            {
+                throw new ArgumentOutOfRangeException(key);
+            }
+
+            return timestamp;
         }
 
         /// <summary>

--- a/CDP4WebServices.API/Services/Revision/IRevisionResolver.cs
+++ b/CDP4WebServices.API/Services/Revision/IRevisionResolver.cs
@@ -33,7 +33,7 @@ namespace CDP4WebServices.API.Services
         /// <param name="revisionFrom"><see cref="int"/> or <see cref="DateTime"/> type parameter that indicates the From revision number, or timestamp.</param>
         /// <param name="revisionTo"><see cref="int"/> or <see cref="DateTime"/> type parameter that indicates the To revision number, or timestamp.</param>
         /// <param name="resolvedValues">A <see cref="ValueTuple"/> containing the resolved From revision number and To revision number.</param>
-        /// <returns></returns>
+        /// <returns>True is revision numbers have been resolved, otherwise false</returns>
         bool TryResolve(NpgsqlTransaction transaction, string partition, object revisionFrom, object revisionTo, out (int FromRevision, int ToRevision, IEnumerable<RevisionRegistryInfo> RevisionRegistryInfoList) resolvedValues);
     }
 }

--- a/CDP4WebServices.API/Services/Revision/IRevisionResolver.cs
+++ b/CDP4WebServices.API/Services/Revision/IRevisionResolver.cs
@@ -1,0 +1,39 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IRevisionResolver.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4WebServices.API.Services
+{
+    using System;
+    using System.Collections.Generic;
+
+    using CDP4Orm.Dao.Revision;
+
+    using CDP4WebServices.API.Services.Protocol;
+
+    using Npgsql;
+
+    /// <summary>
+    /// From the webservices' perspective, the <see cref="IQueryParameters"/> class can contain <see cref="int"/>, or <see cref="DateTime"/> type values for the revisionFrom, and revisionTo query parameters.
+    /// For the <see cref="DateTime"/> type a call has to be made to the datastore, to get the closest revision (before, or after) the specified DateTime value.
+    /// </summary>
+    public interface IRevisionResolver
+    {
+        /// <summary>
+        /// Try to resolve the revision numbers that belong to the revisionFrom and revisionTo parameters.
+        /// </summary>
+        /// <param name="transaction">
+        /// The current transaction to the database.
+        /// </param>
+        /// <param name="partition">
+        /// The database partition (schema) where the requested resource is stored.
+        /// </param>
+        /// <param name="revisionFrom"><see cref="int"/> or <see cref="DateTime"/> type parameter that indicates the From revision number, or timestamp.</param>
+        /// <param name="revisionTo"><see cref="int"/> or <see cref="DateTime"/> type parameter that indicates the To revision number, or timestamp.</param>
+        /// <param name="resolvedValues">A <see cref="ValueTuple"/> containing the resolved From revision number and To revision number.</param>
+        /// <returns></returns>
+        bool TryResolve(NpgsqlTransaction transaction, string partition, object revisionFrom, object revisionTo, out (int FromRevision, int ToRevision, IEnumerable<RevisionRegistryInfo> RevisionRegistryInfoList) resolvedValues);
+    }
+}

--- a/CDP4WebServices.API/Services/Revision/RevisionResolver.cs
+++ b/CDP4WebServices.API/Services/Revision/RevisionResolver.cs
@@ -1,0 +1,84 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RevisionResolver.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4WebServices.API.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Orm.Dao.Revision;
+
+    using Npgsql;
+
+    /// <summary>
+    /// From the webservices' perspective, the <see cref="IQueryParameters"/> class can contain <see cref="int"/>, or <see cref="DateTime"/> type values for the revisionFrom, and revisionTo query parameters.
+    /// For the <see cref="DateTime"/> type a call has to be made to the datastore, to get the closest revision (before, or after) the specified DateTime value.
+    /// </summary>
+    public class RevisionResolver : IRevisionResolver
+    {
+
+        /// <summary>
+        /// The injected instance of <see cref="IRevisionDao"/> that is used to collect RevisionRegistry data
+        /// </summary>
+        public IRevisionDao RevisionDao { get; set; }
+
+        /// <summary>
+        /// Try to resolve the revision numbers that belong to the revisionFrom and revisionTo parameters.
+        /// </summary>
+        /// <param name="transaction">
+        /// The current transaction to the database.
+        /// </param>
+        /// <param name="partition">
+        /// The database partition (schema) where the requested resource is stored.
+        /// </param>
+        /// <param name="revisionFrom"><see cref="int"/> or <see cref="DateTime"/> type parameter that indicates the From revision number, or timestamp.</param>
+        /// <param name="revisionTo"><see cref="int"/> or <see cref="DateTime"/> type parameter that indicates the To revision number, or timestamp.</param>
+        /// <param name="resolvedValues">A <see cref="ValueTuple"/> containing the resolved From revision number and To revision number.</param>
+        /// <returns></returns>
+        public bool TryResolve(NpgsqlTransaction transaction, string partition, object revisionFrom, object revisionTo, out (int FromRevision, int ToRevision, IEnumerable<RevisionRegistryInfo> RevisionRegistryInfoList) resolvedValues)
+        {
+            var resolvedRevisionFrom = 0;
+            var resolvedRevisionTo = int.MaxValue;
+
+            if (revisionFrom == null && revisionTo == null)
+            {
+                resolvedValues = default((int, int, IEnumerable<RevisionRegistryInfo> RevisionRegistryInfoList));
+                return false;
+            }
+
+            var revisions = this.RevisionDao.ReadRevisionRegistry(transaction, partition).ToList();
+
+            if (revisions.Any())
+            {
+                resolvedRevisionFrom = revisions.OrderBy(x => x.Revision).First().Revision;
+                resolvedRevisionTo = revisions.OrderBy(x => x.Revision).Last().Revision;
+            }
+
+            if (revisionFrom is int fromAsInt)
+            {
+                resolvedRevisionFrom = revisions.OrderBy(x => x.Revision).FirstOrDefault(x => x.Revision >= fromAsInt)?.Revision ?? resolvedRevisionFrom;
+            }
+            else if (revisionFrom is DateTime fromAsDateTime)
+            {
+                resolvedRevisionFrom = revisions.OrderBy(x => x.Instant).FirstOrDefault(x => x.Instant >= fromAsDateTime)?.Revision ?? resolvedRevisionFrom;
+            }
+
+            if (revisionTo is int toAsInt)
+            {
+                resolvedRevisionTo = revisions.OrderBy(x => x.Revision).LastOrDefault(x => x.Revision <= toAsInt)?.Revision ?? resolvedRevisionTo;
+            }
+            else if (revisionTo is DateTime toAsDateTime)
+            {
+                resolvedRevisionTo = revisions.OrderBy(x => x.Instant).LastOrDefault(x => x.Instant <= toAsDateTime)?.Revision ?? resolvedRevisionTo;
+            }
+
+            resolvedValues = (resolvedRevisionFrom, resolvedRevisionTo, revisions.Where(x => x.Revision >= resolvedRevisionFrom && x.Revision <= resolvedRevisionTo));
+
+            return true;
+        }
+    }
+}

--- a/CDP4WebServices.API/Services/Revision/RevisionResolver.cs
+++ b/CDP4WebServices.API/Services/Revision/RevisionResolver.cs
@@ -20,7 +20,6 @@ namespace CDP4WebServices.API.Services
     /// </summary>
     public class RevisionResolver : IRevisionResolver
     {
-
         /// <summary>
         /// The injected instance of <see cref="IRevisionDao"/> that is used to collect RevisionRegistry data
         /// </summary>
@@ -38,7 +37,7 @@ namespace CDP4WebServices.API.Services
         /// <param name="revisionFrom"><see cref="int"/> or <see cref="DateTime"/> type parameter that indicates the From revision number, or timestamp.</param>
         /// <param name="revisionTo"><see cref="int"/> or <see cref="DateTime"/> type parameter that indicates the To revision number, or timestamp.</param>
         /// <param name="resolvedValues">A <see cref="ValueTuple"/> containing the resolved From revision number and To revision number.</param>
-        /// <returns></returns>
+        /// <returns>True is revision numbers have been resolved, otherwise false</returns>
         public bool TryResolve(NpgsqlTransaction transaction, string partition, object revisionFrom, object revisionTo, out (int FromRevision, int ToRevision, IEnumerable<RevisionRegistryInfo> RevisionRegistryInfoList) resolvedValues)
         {
             var resolvedRevisionFrom = 0;


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Added the possibility to get revisions by DateTime and or revision number.