### PR TITLE
[WIP] Bug/gh66 verify that iteration setup.is deleted behavior is as per 10 25; fixes #66

### DIFF
--- a/CDP4Authentication/CDP4Authentication.csproj
+++ b/CDP4Authentication/CDP4Authentication.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition.git</RepositoryUrl>    
     <Configurations>Debug;Release;Test</Configurations>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
  
   <ItemGroup>

--- a/CDP4DatabaseAuthentication/CDP4DatabaseAuthentication.csproj
+++ b/CDP4DatabaseAuthentication/CDP4DatabaseAuthentication.csproj
@@ -10,6 +10,7 @@
     <Authors>Sam, Merlin, Alex, Naron</Authors>
     <Configurations>Debug;Release;Test</Configurations>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4Orm.Tests/CDP4Orm.Tests.csproj
+++ b/CDP4Orm.Tests/CDP4Orm.Tests.csproj
@@ -8,6 +8,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4Orm/AutoGenDao/IterationSetupDao.cs
+++ b/CDP4Orm/AutoGenDao/IterationSetupDao.cs
@@ -2,7 +2,7 @@
 // <copyright file="IterationSetupDao.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2019 RHEA System S.A.
 //
-//    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou, Alexander van Delft.
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Nathanael Smiechowski.
 //
 //    This file is part of CDP4 Web Services Community Edition. 
 //    The CDP4 Web Services Community Edition is the RHEA implementation of ECSS-E-TM-10-25 Annex A and Annex C.

--- a/CDP4Orm/AutoGenDao/IterationSetupDao.cs
+++ b/CDP4Orm/AutoGenDao/IterationSetupDao.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationSetupDao.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Nathanael Smiechowski.
 //

--- a/CDP4Orm/CDP4Orm.csproj
+++ b/CDP4Orm/CDP4Orm.csproj
@@ -9,6 +9,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4Orm/Dao/Supplemental/IterationSetupDao.cs
+++ b/CDP4Orm/Dao/Supplemental/IterationSetupDao.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationSetupDao.cs" company="RHEA System S.A.">
 //   Copyright (c) 2016-2020 RHEA System S.A.
+
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Nathanael Smiechowski.
+//
+//    This file is part of CDP4 Web Services Community Edition. 
+//    The CDP4 Web Services Community Edition is the RHEA implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4 Web Services Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4 Web Services Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/CDP4Orm/Dao/Supplemental/IterationSetupDao.cs
+++ b/CDP4Orm/Dao/Supplemental/IterationSetupDao.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationSetupDao.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016 RHEA System S.A.
+//   Copyright (c) 2016-2020 RHEA System S.A.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -105,6 +105,33 @@ namespace CDP4Orm.Dao
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Execute additional logic before each delete function call.
+        /// </summary>
+        /// <param name="transaction">
+        /// The current transaction to the database.
+        /// </param>
+        /// <param name="partition">
+        /// The database partition (schema) where the requested resource will be deleted.
+        /// </param>
+        /// <param name="iid">
+        /// The thing DTO id that is to be deleted.
+        /// </param>
+        /// <param name="isHandled">
+        /// Logic flag that can be set to true to skip the generated deleted logic
+        /// </param>
+        /// <returns>
+        /// True if the concept was deleted.
+        /// </returns>
+        /// <remarks>
+        /// IterationSetups cannot be deleted at all.
+        /// </remarks>>
+        public override bool BeforeDelete(NpgsqlTransaction transaction, string partition, Guid iid, out bool isHandled)
+        {
+            isHandled = true;
+            return true;
         }
     }
 }

--- a/CDP4WebServer/CDP4WebServer.csproj
+++ b/CDP4WebServer/CDP4WebServer.csproj
@@ -10,6 +10,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>    

--- a/CDP4WebService.Authentication/CDP4WebService.Authentication.csproj
+++ b/CDP4WebService.Authentication/CDP4WebService.Authentication.csproj
@@ -9,6 +9,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4WebServices.API.Tests/CDP4WebServices.API.Tests.csproj
+++ b/CDP4WebServices.API.Tests/CDP4WebServices.API.Tests.csproj
@@ -8,6 +8,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4WebServices.API.Tests/SideEffects/IterationSetupSideEffectTestFixture.cs
+++ b/CDP4WebServices.API.Tests/SideEffects/IterationSetupSideEffectTestFixture.cs
@@ -195,6 +195,7 @@ namespace CDP4WebServices.API.Tests.SideEffects
         public void VerifyBeforeDeleteWhenIterationIsFrozenAndMarkItLikeIsDeleted()
         {
             var iterationSetup = this.mockedIterationSetupService.Object.GetShallow(this.npgsqlTransaction, "SiteDirectory", It.IsAny<IEnumerable<Guid>>(), this.mockedSecurityContext.Object).OfType<IterationSetup>().SingleOrDefault();
+            var originalThing = iterationSetup.DeepClone<Thing>();
             iterationSetup.FrozenOn = DateTime.Now;
 
             this.iterationSetupSideEffect.BeforeDelete(
@@ -204,8 +205,18 @@ namespace CDP4WebServices.API.Tests.SideEffects
                 "siteDirectory",
                 this.mockedSecurityContext.Object);
 
+            Assert.AreEqual(iterationSetup.IsDeleted, false);
+
+            this.iterationSetupSideEffect.AfterDelete(
+                iterationSetup,
+                this.engineeringModelSetup,
+                originalThing,
+                this.npgsqlTransaction,
+                "siteDirectory",
+                this.mockedSecurityContext.Object);
+
             Assert.AreEqual(iterationSetup.IsDeleted, true);
-           
+
             this.mockedIterationSetupService.Verify(x => x.UpdateConcept(this.npgsqlTransaction, "siteDirectory", iterationSetup, this.engineeringModelSetup), Times.Once);
         }
     }

--- a/CDP4WebServices.API.Tests/SideEffects/IterationSetupSideEffectTestFixture.cs
+++ b/CDP4WebServices.API.Tests/SideEffects/IterationSetupSideEffectTestFixture.cs
@@ -1,6 +1,24 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationSetupSideEffectTestFixture.cs" company="RHEA System S.A.">
 //   Copyright (c) 2016-2020 RHEA System S.A.
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Nathanael Smiechowski.
+//
+//    This file is part of CDP4 Web Services Community Edition. 
+//    The CDP4 Web Services Community Edition is the RHEA implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4 Web Services Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4 Web Services Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // <summary>
 //   IterationSetup Side Effect test class

--- a/CDP4WebServices.API.Tests/SideEffects/IterationSetupSideEffectTestFixture.cs
+++ b/CDP4WebServices.API.Tests/SideEffects/IterationSetupSideEffectTestFixture.cs
@@ -137,7 +137,7 @@ namespace CDP4WebServices.API.Tests.SideEffects
         }
 
         [Test]
-        public void VerifyBeforeDeleteIsIterationIsCurrentIteration()
+        public void VerifyBeforeDeleteWhenIterationIsCurrentIteration()
         {
             var iterationSetup = this.mockedIterationSetupService.Object.GetShallow(this.npgsqlTransaction, "SiteDirectory", It.IsAny<IEnumerable<Guid>>(), this.mockedSecurityContext.Object).OfType<IterationSetup>().SingleOrDefault();
 
@@ -153,7 +153,7 @@ namespace CDP4WebServices.API.Tests.SideEffects
         }
 
         [Test]
-        public void VerifyBeforeDeleteIsIterationIsFrozenAndDelete()
+        public void VerifyBeforeDeleteWhenIterationIsFrozenAndDeleted()
         {
             var iterationSetup = this.mockedIterationSetupService.Object.GetShallow(this.npgsqlTransaction, "SiteDirectory", It.IsAny<IEnumerable<Guid>>(), this.mockedSecurityContext.Object).OfType<IterationSetup>().SingleOrDefault();
             iterationSetup.FrozenOn=DateTime.Now;
@@ -174,7 +174,7 @@ namespace CDP4WebServices.API.Tests.SideEffects
         }
 
         [Test]
-        public void VerifyBeforeDeleteIsIterationIsFrozenAndDeleteIt()
+        public void VerifyBeforeDeleteWhenIterationIsFrozenAndMarkItLikeIsDeleted()
         {
             var iterationSetup = this.mockedIterationSetupService.Object.GetShallow(this.npgsqlTransaction, "SiteDirectory", It.IsAny<IEnumerable<Guid>>(), this.mockedSecurityContext.Object).OfType<IterationSetup>().SingleOrDefault();
             iterationSetup.FrozenOn = DateTime.Now;

--- a/CDP4WebServices.API/CDP4WebServices.API.csproj
+++ b/CDP4WebServices.API/CDP4WebServices.API.csproj
@@ -9,6 +9,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationSetupSideEffect.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016-2018 RHEA System S.A.
+//   Copyright (c) 2016-2020 RHEA System S.A.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -216,7 +216,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
                 throw new InvalidOperationException("It is not possible to delete the current iteration.");
             }
 
-            if (iterationSetup.IsDeleted)
+            if (iterationSetup.IsDeleted != false)
             {
                 return;
             }

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
@@ -27,6 +27,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
 {
     using System;
     using System.Collections.Generic;
+    using System.Drawing;
     using System.Linq;
     using Authorization;
     using CDP4Common.DTO;
@@ -240,8 +241,129 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
                 return;
             }
 
+            // Swtitch partition to EngineeringModel
+            var engineeringModelPartition = this.RequestUtils.GetEngineeringModelPartitionString(((EngineeringModelSetup)container).EngineeringModelIid);
+
+            // Make sure to switch security context to participant based (as we're going to operate on engineeringmodel data)
+            var credentials = this.RequestUtils.Context.AuthenticatedCredentials;
+            credentials.EngineeringModelSetup = (EngineeringModelSetup)container;
+            this.PersonResolver.ResolveParticipantCredentials(transaction, credentials);
+            this.PermissionService.Credentials = credentials;
+
+            var iteration = this.IterationService.GetShallow(transaction, engineeringModelPartition, new [] {iterationSetup.IterationIid}, securityContext).Cast<Iteration>().SingleOrDefault();
+            this.IterationService.DeleteConcept(transaction, engineeringModelPartition, iteration, container);
+
+            var iteration2 = this.IterationService.GetShallow(transaction, engineeringModelPartition, new[] { iterationSetup.IterationIid }, securityContext).Cast<Iteration>().SingleOrDefault();
+
             iterationSetup.IsDeleted = true;
             this.IterationSetupService.UpdateConcept(transaction, partition, iterationSetup, container);
+        }
+
+        /// <summary>
+        /// Allows derived classes to override and execute additional logic after a successful delete operation.
+        /// </summary>
+        /// <param name="thing">
+        /// The <see cref="Thing"/> instance that will be inspected.
+        /// </param>
+        /// <param name="container">
+        /// The container instance of the <see cref="Thing"/> that is inspected.
+        /// </param>
+        /// <param name="originalThing">
+        /// The original Thing.
+        /// </param>
+        /// <param name="transaction">
+        /// The current transaction to the database.
+        /// </param>
+        /// <param name="partition">
+        /// The database partition (schema) where the requested resource will be stored.
+        /// </param>
+        /// <param name="securityContext">
+        /// The security Context used for permission checking.
+        /// </param>
+        public override void AfterDelete(IterationSetup thing, Thing container, IterationSetup originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
+        {
+            var iterationSetups = this.IterationSetupService.GetShallow(transaction, partition, new[] { thing.Iid }, securityContext).OfType<IterationSetup>();
+            var iterationSetup = iterationSetups.SingleOrDefault();
+
+            var engineeringModelSetup = (EngineeringModelSetup)container;
+            var iterationSetupIidsToUpdate = engineeringModelSetup.IterationSetup.Except(new[] { thing.Iid });
+            var iterationSetupsToUpdate = this.IterationSetupService.GetShallow(transaction, partition, iterationSetupIidsToUpdate, securityContext).OfType<IterationSetup>();
+
+            // Create the iteration for the IterationSetup
+            var engineeringModelIid = engineeringModelSetup.EngineeringModelIid;
+
+            // switch partition to engineeringModel
+            var engineeringModelPartition = this.RequestUtils.GetEngineeringModelPartitionString(engineeringModelIid);
+
+            // make sure to switch security context to participant based (as we're going to operate on engineeringmodel data)
+            var credentials = this.RequestUtils.Context.AuthenticatedCredentials;
+            credentials.EngineeringModelSetup = engineeringModelSetup;
+            this.PersonResolver.ResolveParticipantCredentials(transaction, credentials);
+            this.PermissionService.Credentials = credentials;
+
+            var engineeringModel = this.EngineeringModelService.GetShallow(transaction, engineeringModelPartition, new[] { engineeringModelIid }, securityContext)
+                                                               .SingleOrDefault() as EngineeringModel;
+
+            var sourceIterationSetups = this.IterationSetupService.GetShallow(transaction, Cdp4TransactionManager.SITE_DIRECTORY_PARTITION, engineeringModelSetup.IterationSetup, securityContext)
+                                                                  .Where(x => x.Iid != thing.Iid)
+                                                                  .Cast<IterationSetup>()
+                                                                  .ToList();
+
+            // update iteration partition with source data if applicable
+
+                var sourceIterationSetup = sourceIterationSetups.SingleOrDefault();
+                if (sourceIterationSetup == null)
+                {
+                    throw new InvalidOperationException("The source iteration-setup could not be found.");
+                }
+
+                var lastIterationNumber = sourceIterationSetups.Max(x => x.IterationNumber);
+                var iterationPartition = $"{Cdp4TransactionManager.ITERATION_PARTITION_PREFIX}{engineeringModelIid.ToString().Replace("-", "_")}";
+                if (sourceIterationSetup.IterationNumber != lastIterationNumber)
+                {
+                    this.IterationService.PopulateDataFromOlderIteration(transaction, iterationPartition, thing, sourceIterationSetup, engineeringModel, securityContext);
+                }
+                else
+                {
+                    this.IterationService.PopulateDataFromLastIteration(transaction, iterationPartition, thing, sourceIterationSetup, engineeringModel, securityContext);
+                }
+
+
+            // Create revisions for created Iteration and updated EngineeringModel
+            var actor = credentials.Person.Iid;
+
+            this.TransactionManager.SetDefaultContext(transaction);
+            this.TransactionManager.SetCachedDtoReadEnabled(false);
+            var transactionRevision = this.RevisionService.GetRevisionForTransaction(transaction, engineeringModelPartition);
+            this.RevisionService.SaveRevisions(transaction, engineeringModelPartition, actor, transactionRevision);
+
+            //var iterationSetups = this.IterationSetupService.GetShallow(transaction, partition, new[] { thing.Iid }, securityContext).OfType<IterationSetup>();
+            //var iterationSetup = iterationSetups.SingleOrDefault();
+
+            //var baseErrorString = $"Could not find {nameof(Iteration)}.";
+
+            //if (iterationSetup == null)
+            //{
+            //    throw new KeyNotFoundException($"{baseErrorString}\n{nameof(IterationSetup)} with iid {iterationSetup.Iid} could not be found.");
+            //}
+
+            //var engineeringModelSetup = (EngineeringModelSetup)container;
+
+            //var engineeringModelPartition = this.RequestUtils.GetEngineeringModelPartitionString(((EngineeringModelSetup)container).EngineeringModelIid);
+
+            //var updatedIteration = this.IterationService
+            //    .GetShallow(transaction, engineeringModelPartition, new[] { iterationSetup.IterationIid }, securityContext)
+            //    .Cast<Iteration>()
+            //    .SingleOrDefault();
+
+            //var engineeringModel = this.EngineeringModelService
+            //    .GetShallow(transaction, engineeringModelPartition,
+            //        new[] { engineeringModelSetup.EngineeringModelIid }, securityContext).Cast<EngineeringModel>()
+            //    .SingleOrDefault();
+
+
+            //this.EngineeringModelService.UpdateConcept(transaction, engineeringModelPartition, engineeringModel, container);
+
         }
 
         /// <summary>

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IterationSetupSideEffect.cs" company="RHEA System S.A.">
 //   Copyright (c) 2016-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Nathanael Smiechowski.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
@@ -294,11 +294,8 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
                 var engineeringModelPartition = this.RequestUtils.GetEngineeringModelPartitionString(((EngineeringModelSetup)container).EngineeringModelIid);
                 var credentials = this.RequestUtils.Context.AuthenticatedCredentials;
 
-                // Create revisions for created Iteration and updated EngineeringModel
+                // Create revisions for deleted Iteration and updated EngineeringModel
                 var actor = credentials.Person.Iid;
-
-                this.TransactionManager.SetDefaultContext(transaction);
-                this.TransactionManager.SetCachedDtoReadEnabled(false);
                 var transactionRevision = this.RevisionService.GetRevisionForTransaction(transaction, engineeringModelPartition);
                 this.RevisionService.SaveRevisions(transaction, engineeringModelPartition, actor, transactionRevision);
             }

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/IterationSetupSideEffect.cs
@@ -291,10 +291,11 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
                 iterationSetup.IsDeleted = true;
                 this.IterationSetupService.UpdateConcept(transaction, partition, iterationSetup, container);
 
+                // Swtitch partition to EngineeringModel
                 var engineeringModelPartition = this.RequestUtils.GetEngineeringModelPartitionString(((EngineeringModelSetup)container).EngineeringModelIid);
-                var credentials = this.RequestUtils.Context.AuthenticatedCredentials;
 
                 // Create revisions for deleted Iteration and updated EngineeringModel
+                var credentials = this.RequestUtils.Context.AuthenticatedCredentials;
                 var actor = credentials.Person.Iid;
                 var transactionRevision = this.RevisionService.GetRevisionForTransaction(transaction, engineeringModelPartition);
                 this.RevisionService.SaveRevisions(transaction, engineeringModelPartition, actor, transactionRevision);

--- a/CDP4WebServices.API/config_debug.json
+++ b/CDP4WebServices.API/config_debug.json
@@ -7,7 +7,7 @@
     "FileStorageDirectory": "storage"
   },
   "Backtier": {
-    "HostName": "localhost",
+    "HostName": "cdp4-postgresql",
     "Port": 5432,
     "UserName": "cdp4",
     "Password": "cdp4",

--- a/CDP4WebServices.API/config_debug.json
+++ b/CDP4WebServices.API/config_debug.json
@@ -7,7 +7,7 @@
     "FileStorageDirectory": "storage"
   },
   "Backtier": {
-    "HostName": "cdp4-postgresql",
+    "HostName": "localhost",
     "Port": 5432,
     "UserName": "cdp4",
     "Password": "cdp4",


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

- [x] Added BeforeDelete method in IterationSetupSideEffect, where validate IterationSetup.isDeleted an IterationSetup.FrozenOn.
- [x] Added test that check solution.
<!-- Thanks for contributing to CDP4 Web Services! -->