### PR TITLE
GH110-Verify behaviour of DomainFileStore creation or deletion when EngineeringModelSetup is updated; fixes #110

### DIFF
--- a/CDP4Authentication/CDP4Authentication.csproj
+++ b/CDP4Authentication/CDP4Authentication.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/RHEAGROUP/CDP4-SDK-Community-Edition.git</RepositoryUrl>    
     <Configurations>Debug;Release;Test</Configurations>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
  
   <ItemGroup>

--- a/CDP4DatabaseAuthentication/CDP4DatabaseAuthentication.csproj
+++ b/CDP4DatabaseAuthentication/CDP4DatabaseAuthentication.csproj
@@ -10,6 +10,7 @@
     <Authors>Sam, Merlin, Alex, Naron</Authors>
     <Configurations>Debug;Release;Test</Configurations>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4Orm.Tests/CDP4Orm.Tests.csproj
+++ b/CDP4Orm.Tests/CDP4Orm.Tests.csproj
@@ -8,6 +8,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4Orm/CDP4Orm.csproj
+++ b/CDP4Orm/CDP4Orm.csproj
@@ -9,6 +9,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4WebServer/CDP4WebServer.csproj
+++ b/CDP4WebServer/CDP4WebServer.csproj
@@ -10,6 +10,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>    

--- a/CDP4WebService.Authentication/CDP4WebService.Authentication.csproj
+++ b/CDP4WebService.Authentication/CDP4WebService.Authentication.csproj
@@ -9,6 +9,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4WebServices.API.Tests/CDP4WebServices.API.Tests.csproj
+++ b/CDP4WebServices.API.Tests/CDP4WebServices.API.Tests.csproj
@@ -8,6 +8,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4WebServices.API/CDP4WebServices.API.csproj
+++ b/CDP4WebServices.API/CDP4WebServices.API.csproj
@@ -9,6 +9,7 @@
     <Copyright>Copyright © RHEA System S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander</Authors>
     <Configurations>Debug;Release;Test</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/EngineeringModelSetupSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/EngineeringModelSetupSideEffect.cs
@@ -1,6 +1,26 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelSetupSideEffect.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016-2018 RHEA System S.A.
+//   Copyright (c) 2016-2020 RHEA System S.A.
+
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4 Web Services Community Edition. 
+//    The CDP4 Web Services Community Edition is the RHEA implementation of ECSS-E-TM-10-25 Annex A and Annex C.
+//    This is an auto-generated class. Any manual changes to this file will be overwritten!
+//
+//    The CDP4 Web Services Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+//
+//    The CDP4 Web Services Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
…delSetupSideEffect

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

- [x] I deleted AfterUpdate method in EngineeringModelSetupSideEffect. This method was responsible for injection whole bunch of domainFileStore after creation / update EngineeringModelSetup.

- [x] I checked UnitTest and IntegrationTest accordingly to my changes

<!-- Thanks for contributing to CDP4 Web Services! -->