### PR TITLE
GH103-Internal-Server-Error-Invalid-Cast; fixes #103

### DIFF
--- a/CDP4WebServices.API/Services/Operations/OperationProcessor.cs
+++ b/CDP4WebServices.API/Services/Operations/OperationProcessor.cs
@@ -635,6 +635,8 @@ namespace CDP4WebServices.API.Services.Operations
 
                         return true;
                     }
+
+                    continue;
                 }
 
                 // Check if the found container property includes the supplied id.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
When we would like to create SiteReferenceDataLibrary that contain two (or more) CompoundParamaterType, one of the loop responsible for the finding information about supplied thing type in the Create operation couldn't end the interval. It occurs because supplied thing was compare only with the container of the first CompoundParameterType and because of exception that this thing is not in the container, the loop was not able to jump into second CompoundParameterType in the List.
<!-- Thanks for contributing to CDP4 Web Services! -->