### PR TITLE
Bad async multipart fix; fixes #112

### DIFF
--- a/CDP4WebServices.API/Modules/10-25/ApiBase.cs
+++ b/CDP4WebServices.API/Modules/10-25/ApiBase.cs
@@ -33,6 +33,7 @@ namespace CDP4WebServices.API.Modules
     using System.Net.Http;
     using System.Security.Cryptography;
     using System.Text;
+    using System.Threading.Tasks;
 
     using CDP4Common.DTO;
 
@@ -832,7 +833,7 @@ namespace CDP4WebServices.API.Modules
             }
 
             // stream the multipart content to the request contents target stream
-            content.CopyToAsync(targetStream);
+            content.CopyToAsync(targetStream).Wait();
             this.AddMultiPartMimeEndpoint(targetStream);
         }
 
@@ -906,7 +907,7 @@ namespace CDP4WebServices.API.Modules
                 content.Add(binaryContent);
 
                 // stream the multipart content to the request contents target stream
-                content.CopyToAsync(targetStream);
+                content.CopyToAsync(targetStream).Wait();
 
                 this.AddMultiPartMimeEndpoint(targetStream);
             }
@@ -949,7 +950,7 @@ namespace CDP4WebServices.API.Modules
                 var content = new ByteArrayContent(buffer);
 
                 // stream the multipart content to the request contents target stream
-                content.CopyToAsync(targetStream);
+                content.CopyToAsync(targetStream).Wait();
             }
 
             System.IO.File.Delete(path);

--- a/compose.bat
+++ b/compose.bat
@@ -19,7 +19,19 @@ IF %1==devtest GOTO DevTest
 IF %1==devtestbg GOTO DevTestBg
 IF %1==devdown GOTO DevDown
 IF %1==devtestdown GOTO DevTestDown
+IF %1==nginx GOTO Serv
+IF %1==nginxdown GOTO ServDown
 
+GOTO End
+
+:Serv
+rem Need to build the application in Release before making the image
+CALL MSBuild.exe CDP4-Server.sln -property:Configuration=Release -restore
+START /B docker-compose -f docker-compose-nginx.yml up --build
+GOTO End
+
+:ServDown
+START /B docker-compose -f docker-compose-nginx.yml down --remove-orphans
 GOTO End
 
 :Build

--- a/compose.bat
+++ b/compose.bat
@@ -24,7 +24,7 @@ GOTO End
 
 :Build
 rem Need to build the application in Release before making the image
-START /B MSBuild.exe CDP4-Server.sln -property:Configuration=Release -restore
+CALL MSBuild.exe CDP4-Server.sln -property:Configuration=Release -restore
 START /B docker-compose up --build
 GOTO End
 

--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -1,0 +1,65 @@
+version: '3.8'
+services:
+  
+  cdp4_db:
+    image: rheagroup/cdp4-database-community-edition:latest
+    hostname: cdp4-postgresql
+    command: postgres -c max_locks_per_transaction=1024
+    environment:
+      - POSTGRES_PASSWORD=${DB_POSTGRESPASSWORD}
+      - POSTGRES_USER=postgres
+    networks:
+      cdp4:
+        aliases:
+          - cdp4-postgresql
+    container_name: cdp4-database-community-edition
+    restart: always
+    ports:
+      - '${DB_HOSTPORT}:5432'
+    expose:
+      - '5432'
+    volumes:
+      - cdpdbdata:/var/lib/postgresql/data
+      - cdpdblogs:/logs
+
+  cdp4_webservices:
+    hostname: cdp4-webservices
+    restart: always
+    build: .
+    networks:
+      cdp4:
+        aliases:
+          - cdp4-webservices
+    depends_on:
+      - cdp4_db
+    expose:
+      - '5000'
+    volumes:
+      - cdpwslogs:/app/logs
+      - cdpwsstorage:/app/storage
+      - cdpwsupload:/app/upload
+
+  nginx: 
+    image: nginx:latest
+    container_name: cdp4-nginx
+    restart: always
+    depends_on:
+      - cdp4_webservices
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - 80:80
+    networks:
+      cdp4:
+        aliases:
+          - cdp4-nginx
+
+networks:
+  cdp4:
+
+volumes:
+  cdpdbdata:
+  cdpdblogs:
+  cdpwslogs:
+  cdpwsstorage:
+  cdpwsupload:

--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -48,7 +48,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
     ports:
-      - 80:80
+      - 8088:80
     networks:
       cdp4:
         aliases:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,15 @@
+events {
+
+}
+
+http {
+        error_log /etc/nginx/error_log.log warn;
+
+        server {
+                listen 80;
+
+                location / {
+                        proxy_pass http://cdp4-webservices:5000;
+                }
+        }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Turns out this was a problem not just for nginx but for containers also! Async stream copying was not awaited and would cutoff for some reason on linux machines but not while debugging on windows.

Added simple nginx compose configuration to be able to spin up a local proxyserver to test against port 80.

NOTE: if nginx compose is used, webservices are no longer exposed on 5000.