### PR TITLE
Autovacuum migration now inline with migration procedure

### DIFF
--- a/CDP4Orm/MigrationScript/All_OnStartUpOnly_20200810_6_2_0_0_Autovacuum.sql
+++ b/CDP4Orm/MigrationScript/All_OnStartUpOnly_20200810_6_2_0_0_Autovacuum.sql
@@ -1,13 +1,13 @@
 ﻿DO $$DECLARE r record;
 BEGIN
     FOR r IN 
-        (SELECT 'ALTER TABLE "'|| schemaname || '"."' || tablename ||'" SET (autovacuum_vacuum_scale_factor = 0.0);' as a FROM pg_tables WHERE NOT schemaname IN ('pg_catalog', 'information_schema') ORDER BY schemaname, tablename)
+        (SELECT 'ALTER TABLE "SchemaName_Replace"."' || tablename ||'" SET (autovacuum_vacuum_scale_factor = 0.0);' as a FROM pg_tables WHERE schemaname='SchemaName_Replace' ORDER BY tablename)
 		union all
-		(SELECT 'ALTER TABLE "'|| schemaname || '"."' || tablename ||'" SET (autovacuum_vacuum_threshold = 2500);' as a FROM pg_tables WHERE NOT schemaname IN ('pg_catalog', 'information_schema') ORDER BY schemaname, tablename)
+		(SELECT 'ALTER TABLE "SchemaName_Replace"."' || tablename ||'" SET (autovacuum_vacuum_threshold = 2500);' as a FROM pg_tables WHERE schemaname='SchemaName_Replace' ORDER BY tablename)
 		union all
-		(SELECT 'ALTER TABLE "'|| schemaname || '"."' || tablename ||'" SET (autovacuum_analyze_scale_factor = 0.0);' as a FROM pg_tables WHERE NOT schemaname IN ('pg_catalog', 'information_schema') ORDER BY schemaname, tablename)
+		(SELECT 'ALTER TABLE "SchemaName_Replace"."' || tablename ||'" SET (autovacuum_analyze_scale_factor = 0.0);' as a FROM pg_tables WHERE schemaname='SchemaName_Replace' ORDER BY tablename)
 		union all
-		(SELECT 'ALTER TABLE "'|| schemaname || '"."' || tablename ||'" SET (autovacuum_analyze_threshold = 2500);' as a FROM pg_tables WHERE NOT schemaname IN ('pg_catalog', 'information_schema') ORDER BY schemaname, tablename)
+		(SELECT 'ALTER TABLE "SchemaName_Replace"."' || tablename ||'" SET (autovacuum_analyze_threshold = 2500);' as a FROM pg_tables WHERE schemaname='SchemaName_Replace' ORDER BY tablename)
 		LOOP
         EXECUTE r.a;
     END LOOP;

--- a/CDP4WebServer/Program.cs
+++ b/CDP4WebServer/Program.cs
@@ -7,6 +7,7 @@
 namespace CDP4WebServer
 {
     using System;
+    using System.Reflection;
 
     using CDP4WebServices.API.Configuration;
 
@@ -39,7 +40,8 @@ namespace CDP4WebServer
         {
             try
             {
-                Logger.Info("Starting CDP4 Services");
+                Logger.Info("################################################################");
+                Logger.Info($"Starting CDP4 Services v{Assembly.GetEntryAssembly().GetName().Version}");
 
                 // load application configuration from file
                 AppConfig.Load();


### PR DESCRIPTION
Autovacuum migration now inline with migration procedure and is doing and is doing way less useless stuff.

Server version in logs.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to CDP4 Web Services! -->