### PR TITLE
#165 New cyclic checks fixes

### DIFF
--- a/CDP4WebServices.API.Tests/SideEffects/DerivedQuantityKindSideEffectTestFixture.cs
+++ b/CDP4WebServices.API.Tests/SideEffects/DerivedQuantityKindSideEffectTestFixture.cs
@@ -218,7 +218,7 @@ namespace CDP4WebServices.API.Tests.SideEffects
         {
             var rawUpdateInfo = new ClasslessDTO
             {
-                { "QuantityKindFactor", new List<Guid> { this.derivedQkOutsideRdlFactor.Iid } }
+                { "QuantityKindFactor", new List<OrderedItem> { new OrderedItem { K = 2, V = this.derivedQkOutsideRdlFactor.Iid } } }
             };
 
             Assert.Throws<AcyclicValidationException>(
@@ -236,7 +236,7 @@ namespace CDP4WebServices.API.Tests.SideEffects
         {
             var rawUpdateInfo = new ClasslessDTO
             {
-                { "QuantityKindFactor", new List<Guid> { this.derivedQkCyclicFactor.Iid } }
+                { "QuantityKindFactor", new List<OrderedItem> { new OrderedItem { K = 2, V = this.derivedQkCyclicFactor.Iid } } }
             };
 
             Assert.Throws<AcyclicValidationException>(
@@ -254,7 +254,7 @@ namespace CDP4WebServices.API.Tests.SideEffects
         {
             var rawUpdateInfo = new ClasslessDTO
             {
-                { "QuantityKindFactor", new List<Guid> { this.derivedQkFactor.Iid } }
+                { "QuantityKindFactor", new List<OrderedItem> { new OrderedItem { K = 2, V = this.derivedQkFactor.Iid } } }
             };
 
             Assert.DoesNotThrow(

--- a/CDP4WebServices.API/Services/Operations/OperationProcessor.cs
+++ b/CDP4WebServices.API/Services/Operations/OperationProcessor.cs
@@ -26,25 +26,30 @@
 
 namespace CDP4WebServices.API.Services.Operations
 {
+    using CDP4Common;
+    using CDP4Common.CommonData;
+    using CDP4Common.DTO;
+    using CDP4Common.Exceptions;
+    using CDP4Common.MetaInfo;
+    using CDP4Common.Types;
+
+    using CDP4Orm.Dao;
+    using CDP4Orm.Dao.Resolve;
+
+    using CDP4WebServices.API.Services.Authorization;
+    using CDP4WebServices.API.Services.Operations.SideEffects;
+
+    using NLog;
+
+    using Npgsql;
+
     using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Security;
-    using CDP4Common;
-    using CDP4Common.CommonData;
-    using CDP4Common.Dto;
-    using CDP4Common.DTO;
-    using CDP4Common.Exceptions;
-    using CDP4Common.MetaInfo;
-    using CDP4Common.Types;
-    using CDP4Orm.Dao;
-    using CDP4Orm.Dao.Resolve;
-    using CDP4WebServices.API.Services.Authorization;
-    using CDP4WebServices.API.Services.Operations.SideEffects;
-    using NLog;
-    using Npgsql;
+
     using IServiceProvider = CDP4WebServices.API.Services.IServiceProvider;
     using Thing = CDP4Common.DTO.Thing;
 

--- a/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/DerivedQuantityKindSideEffect.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/Implementation/DerivedQuantityKindSideEffect.cs
@@ -31,6 +31,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
 
     using CDP4Common;
     using CDP4Common.DTO;
+    using CDP4Common.Types;
 
     using CDP4WebServices.API.Helpers;
     using CDP4WebServices.API.Services.Authorization;
@@ -94,7 +95,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
                 return;
             }
 
-            var quantityKindFactorIids = (List<Guid>)rawUpdateInfo["QuantityKindFactor"];
+            var quantityKindFactorIids = (List<OrderedItem>)rawUpdateInfo["QuantityKindFactor"];
             var referenceDataLibrary = (ReferenceDataLibrary)container;
 
             // Check that all referenced QuantityKinds are from the same RDL chain
@@ -109,7 +110,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
                 .Select(x => x.Iid));
 
             var quantityKindFactors = this.QuantityKindFactorService
-                .Get(transaction, partition, quantityKindFactorIids, securityContext)
+                .Get(transaction, partition, quantityKindFactorIids.Select(x => Guid.Parse(x.V.ToString())), securityContext)
                 .Cast<QuantityKindFactor>();
 
             var quantityKinds = this.QuantityKindService

--- a/CDP4WebServices.API/Services/Operations/SideEffects/OperationSideEffectProcessor.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/OperationSideEffectProcessor.cs
@@ -84,7 +84,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// </returns>
         public IOperationSideEffect GetOperationSideEffect(Thing thing)
         {
-            return this.operationSideEffectMap[this.GetTypeName(thing)];
+            return this.operationSideEffectMap[GetTypeName(thing)];
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// </returns>
         public bool IsSideEffectRegistered(Thing thing)
         {
-            return this.operationSideEffectMap.ContainsKey(this.GetTypeName(thing));
+            return this.operationSideEffectMap.ContainsKey(GetTypeName(thing));
         }
 
         /// <summary>
@@ -318,9 +318,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// <returns>
         /// The type name of a <see cref="Thing"/>.
         /// </returns>
-        private string GetTypeName(Thing thing)
+        private static string GetTypeName(Thing thing)
         {
-            return thing != null ? thing.GetType().Name : null;
+            return thing?.GetType().Name;
         }
     }
 }

--- a/CDP4WebServices.API/Services/Operations/SideEffects/OperationSideEffectProcessor.cs
+++ b/CDP4WebServices.API/Services/Operations/SideEffects/OperationSideEffectProcessor.cs
@@ -8,9 +8,12 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using CDP4Common;
     using CDP4Common.DTO;
+    using CDP4Common.MetaInfo;
+
     using CDP4WebServices.API.Services.Authorization;
     using NLog;
     using Npgsql;
@@ -29,6 +32,11 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// The operation side effect map.
         /// </summary>
         private readonly Dictionary<string, IOperationSideEffect> operationSideEffectMap = new Dictionary<string, IOperationSideEffect>();
+
+        /// <summary>
+        /// Gets or sets the <see cref="IRequestUtils"/>.
+        /// </summary>
+        public IRequestUtils RequestUtils { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OperationSideEffectProcessor"/> class. 
@@ -116,6 +124,34 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         }
 
         /// <summary>
+        /// Gets all applicable side effects for the given <paramref name="thing"/> by going up the inheritance chain
+        /// and returning the associated <see cref="IOperationSideEffect"/> for each class that has defined one.
+        /// Note that this list includes the <see cref="IOperationSideEffect"/> for the given <paramref name="thing"/>
+        /// as well.
+        /// </summary>
+        /// <param name="thing">
+        /// The given <see cref="Thing"/>.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> of all applicable side effects.
+        /// </returns>
+        private IEnumerable<IOperationSideEffect> SideEffects(Thing thing)
+        {
+            var type = GetTypeName(thing);
+
+            do
+            {
+                if (this.IsSideEffectRegistered(type))
+                {
+                    yield return this.GetOperationSideEffect(type);
+                }
+
+                var metaInfo = this.RequestUtils.MetaInfoProvider.GetMetaInfo(type);
+                type = metaInfo.BaseType;
+            } while (!string.IsNullOrEmpty(type));
+        }
+
+        /// <summary>
         /// Predicate to determine if a property will be validated.
         /// </summary>
         /// <param name="thing">
@@ -125,12 +161,11 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// The property name.
         /// </param>
         /// <returns>
-        /// true if the passed in property name is to be validated,
-        /// false to skip validation
+        /// True if the passed in property name is to be validated, false to skip validation.
         /// </returns>
         public bool ValidateProperty(Thing thing, string propertyName)
         {
-            return !this.IsSideEffectRegistered(thing) || this.GetOperationSideEffect(thing).ValidateProperty(thing, propertyName);
+            return this.SideEffects(thing).All(sideEffect => sideEffect.ValidateProperty(thing, propertyName));
         }
 
         /// <summary>
@@ -152,17 +187,11 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// The security Context used for permission checking.
         /// </param>
         /// <returns>
-        /// Return a boolean specifying whether the operation shall be executed
+        /// Returns a boolean specifying whether the operation shall be executed.
         /// </returns>
         public bool BeforeCreate(Thing thing, Thing container, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
-            if (this.IsSideEffectRegistered(thing))
-            {
-                return this.GetOperationSideEffect(thing).BeforeCreate(thing, container, transaction, partition, securityContext);
-            }
-
-            // if no side-effect just return true
-            return true;
+            return this.SideEffects(thing).All(sideEffect => sideEffect.BeforeCreate(thing, container, transaction, partition, securityContext));
         }
 
         /// <summary>
@@ -188,9 +217,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// </param>
         public void AfterCreate(Thing thing, Thing container, Thing originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
-            if (this.IsSideEffectRegistered(thing))
+            foreach (var sideEffect in this.SideEffects(thing))
             {
-                this.GetOperationSideEffect(thing).AfterCreate(thing, container, originalThing, transaction, partition, securityContext);
+                sideEffect.AfterCreate(thing, container, originalThing, transaction, partition, securityContext);
             }
         }
 
@@ -219,9 +248,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// </param>
         public void BeforeUpdate(Thing thing, Thing container, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext, ClasslessDTO rawUpdateInfo)
         {
-            if (this.IsSideEffectRegistered(thing))
+            foreach (var sideEffect in this.SideEffects(thing))
             {
-                this.GetOperationSideEffect(thing).BeforeUpdate(thing, container, transaction, partition, securityContext, rawUpdateInfo);
+                sideEffect.BeforeUpdate(thing, container, transaction, partition, securityContext, rawUpdateInfo);
             }
         }
 
@@ -248,9 +277,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// </param>
         public void AfterUpdate(Thing thing, Thing container, Thing originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
-            if (this.IsSideEffectRegistered(thing))
+            foreach (var sideEffect in this.SideEffects(thing))
             {
-                this.GetOperationSideEffect(thing).AfterUpdate(thing, container, originalThing, transaction, partition, securityContext);
+                sideEffect.AfterUpdate(thing, container, originalThing, transaction, partition, securityContext);
             }
         }
 
@@ -274,9 +303,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// </param>
         public void BeforeDelete(Thing thing, Thing container, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
-            if (this.IsSideEffectRegistered(thing))
+            foreach (var sideEffect in this.SideEffects(thing))
             {
-                this.GetOperationSideEffect(thing).BeforeDelete(thing, container, transaction, partition, securityContext);
+                sideEffect.BeforeDelete(thing, container, transaction, partition, securityContext);
             }
         }
 
@@ -303,9 +332,9 @@ namespace CDP4WebServices.API.Services.Operations.SideEffects
         /// </param>
         public void AfterDelete(Thing thing, Thing container, Thing originalThing, NpgsqlTransaction transaction, string partition, ISecurityContext securityContext)
         {
-            if (this.IsSideEffectRegistered(thing))
+            foreach (var sideEffect in this.SideEffects(thing))
             {
-                this.GetOperationSideEffect(thing).AfterDelete(thing, container, originalThing, transaction, partition, securityContext);
+                sideEffect.AfterDelete(thing, container, originalThing, transaction, partition, securityContext);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes needed for the newly implemented cyclic checks:
* Use OrderedItem over Guid for QuantityKindFactor List.
* Call all applicable side effects up the inheritance chain.

Other discovered issues which should be handled separately:
* There seems to be no (or at least some missing) server-side validation regarding property types; sending the wrong type for a property (e.g. a list of Guids instead of a list of OrderedItems) results in a generic server error instead of a proper server response.
* Acyclic validation errors are reported as generic 500s, leading to a poor way of handling them at the other end. Server errors should be properly split into categories with appropriate HTTP error codes and details/response bodies.
* The method `IMetaInfo.BaseType` declares that it returns `The base type or the same type name if class is the inheritance root`; however, for the inheritance root, it actually returns an empty string.