### PR TITLE
Added capability to do EM replacement tokens in Iteration migrations.…

### DIFF
--- a/CDP4Orm/MigrationEngine/GenericMigration.cs
+++ b/CDP4Orm/MigrationEngine/GenericMigration.cs
@@ -59,11 +59,25 @@ namespace CDP4Orm.MigrationEngine
 
             foreach (var applicableSchema in applicableSchemas)
             {
+                var replaceList = new List<Tuple<string, string>>();
+
                 // using the actual schema name in the generic script to execute
                 var replace = new Tuple<string, string>(SCHEMA_NAME_REPLACE, applicableSchema);
+                replaceList.Add(replace);
+
+                // allow possibility of replacing engineeringmodel tokens in iterations
+                if (this.MigrationMetaData.MigrationScriptApplicationKind == MigrationScriptApplicationKind.Iteration)
+                {
+                    if (applicableSchema.Contains("Iteration_"))
+                    {
+                        var applicableEngineeringModelSchema = applicableSchema.Replace("Iteration_", "EngineeringModel_");
+                        replaceList.Add(new Tuple<string, string>(ENGINEERING_MODEL_REPLACE, applicableEngineeringModelSchema));
+                    }
+                }
+
                 using (var sqlCommand = new NpgsqlCommand())
                 {
-                    sqlCommand.ReadSqlFromResource(this.MigrationMetaData.ResourceName, null, new [] { replace });
+                    sqlCommand.ReadSqlFromResource(this.MigrationMetaData.ResourceName, null, replaceList);
 
                     sqlCommand.Connection = transaction.Connection;
                     sqlCommand.Transaction = transaction;

--- a/CDP4Orm/MigrationEngine/MigrationBase.cs
+++ b/CDP4Orm/MigrationEngine/MigrationBase.cs
@@ -23,7 +23,12 @@ namespace CDP4Orm.MigrationEngine
         /// The string to replace in the script for schema partition
         /// </summary>
         protected const string SCHEMA_NAME_REPLACE = "SchemaName_Replace";
-        
+
+        /// <summary>
+        /// The string to replace in the script for engineeringModel partition
+        /// </summary>
+        protected const string ENGINEERING_MODEL_REPLACE = "EngineeringModel_Replace";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MigrationBase"/> class
         /// </summary>

--- a/CDP4Orm/MigrationScript/Iteration_20210109_6_5_0_0_Model_Updates.sql
+++ b/CDP4Orm/MigrationScript/Iteration_20210109_6_5_0_0_Model_Updates.sql
@@ -50,7 +50,7 @@ CREATE TRIGGER elementdefinition_organizationalparticipant_apply_revision
   BEFORE INSERT OR UPDATE OR DELETE 
   ON "SchemaName_Replace"."ElementDefinition_OrganizationalParticipant"
   FOR EACH ROW
-  EXECUTE PROCEDURE "SiteDirectory".revision_management('ElementDefinition', 'SchemaName_Replace');
+  EXECUTE PROCEDURE "SiteDirectory".revision_management('ElementDefinition', 'EngineeringModel_Replace');
 
 CREATE OR REPLACE FUNCTION "SchemaName_Replace"."ElementDefinition_OrganizationalParticipant_Data" ()
     RETURNS SETOF "SchemaName_Replace"."ElementDefinition_OrganizationalParticipant" AS


### PR DESCRIPTION
… Fixed Organizational participant bug.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Iteration migrations need to be able to support reference replacement tokens for EMs as some functions reside in different schema than the default one. Case in point the migration included.