### PR TITLE
Enable obfuscation of ModelLogEntry

### DIFF
--- a/CDP4WebServices.API/Cdp4Bootstrapper.cs
+++ b/CDP4WebServices.API/Cdp4Bootstrapper.cs
@@ -109,7 +109,6 @@ namespace CDP4WebServices.API
                     builder.RegisterTypeAsPropertyInjectedSingleton<PersonService, IPersonService>();
                     builder.RegisterTypeAsPropertyInjectedSingleton<AuthenticationPluginInjector, IAuthenticationPluginInjector>();
                     builder.RegisterTypeAsPropertyInjectedSingleton<PersonResolver, IPersonResolver>();
-                    builder.RegisterTypeAsPropertyInjectedSingleton<ObfuscationService, IObfuscationService>();
                     builder.RegisterTypeAsPropertyInjectedSingleton<UserValidator, IUserValidator>();
                     builder.RegisterTypeAsPropertyInjectedSingleton<CDP4WebServiceAuthentication, ICDP4WebServiceAuthentication>();
                     builder.RegisterTypeAsPropertyInjectedSingleton<MigrationService, IMigrationService>();
@@ -140,6 +139,9 @@ namespace CDP4WebServices.API
             container.Update(
                 builder =>
                 {
+                    // obfuscation service
+                    builder.RegisterTypeAsPropertyInjectedSingleton<ObfuscationService, IObfuscationService>();
+
                     // local storage controller to stream binary to disk
                     builder.RegisterTypeAsPropertyInjectedSingleton<LocalFileStorage, ILocalFileStorage>();
 


### PR DESCRIPTION
### Prerequisites

- [х] I have written a descriptive pull-request title
- [х] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/pulls) open
- [х] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
ModelLogEntries are now also obfuscated if `AffectedItemIid` contains any Iid of an obfuscated thing. Obfuscation service moved to request based service.