### PR TITLE
Change default log writing to console instead of Loki.

### DIFF
--- a/CometServer/CometServer.csproj
+++ b/CometServer/CometServer.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Carter" Version="10.0.0" />
-    <PackageReference Include="CDP4MessagePackSerializer-CE" Version="30.1.1" />
+    <PackageReference Include="CDP4MessagePackSerializer-CE" Version="30.1.2" />
     <PackageReference Include="CDP4ServicesMessaging-CE" Version="30.1.0" />
     <PackageReference Include="FluentResults" Version="4.0.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />

--- a/CometServer/CometServer.csproj
+++ b/CometServer/CometServer.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Carter" Version="10.0.0" />
-    <PackageReference Include="CDP4MessagePackSerializer-CE" Version="30.1.0" />
+    <PackageReference Include="CDP4MessagePackSerializer-CE" Version="30.1.1" />
     <PackageReference Include="CDP4ServicesMessaging-CE" Version="30.1.0" />
     <PackageReference Include="FluentResults" Version="4.0.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />

--- a/CometServer/appsettings.Production.json
+++ b/CometServer/appsettings.Production.json
@@ -90,19 +90,7 @@
     },
     "WriteTo": [
       {
-        "Name": "GrafanaLoki",
-        "Args": {
-          "uri": "http://localhost:3100",
-          "labels": [
-            {
-              "key": "app",
-              "value": "CDP4-COMET WebServices-01"
-            }
-          ],
-          "propertiesAsLabels": [
-            "app"
-          ]
-        }
+        "Name": "Console"
       }
     ],
     "WriteTo:Async": {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #400.
With the default log writing onto loki, as there are no loki available in a classic deployment, the WebServices stores all logs waiting access to a loki deployment.
Stores all logs -> memory increases --> Crashes the app eventually.

<!-- Thanks for contributing to COMET Web Services! -->